### PR TITLE
feat: add simple support for tracing and observability

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4,9 +4,15 @@ import logging
 import os
 from datetime import datetime
 
+from autogen_agentchat import TRACE_LOGGER_NAME
 from autogen_agentchat.ui import Console
-from autogen_core import TRACE_LOGGER_NAME
 from dotenv import load_dotenv
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.semconv.resource import ResourceAttributes
 
 from utils.logging import format_json_string_factory
 from workflows.planning import PlanningWorkflow
@@ -23,20 +29,55 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s",
 )
 
-logger = logging.getLogger(TRACE_LOGGER_NAME)
-logger.addHandler(logging.StreamHandler())
-logger.setLevel(logging.INFO)
+# For trace logging.
+trace_logger = logging.getLogger(TRACE_LOGGER_NAME)
+trace_logger.addHandler(logging.StreamHandler())
+trace_logger.setLevel(logging.INFO)
 
 
 def parse_args():
-    parser = argparse.ArgumentParser("Ofnil Agentic RAG CLI")
+    parser = argparse.ArgumentParser("Sagi CLI")
     parser.add_argument("--env", type=str, choices=["dev", "prod"], default="dev")
     parser.add_argument("--config", type=str, default="workflows/planning.toml")
+    parser.add_argument(
+        "--trace", action="store_true", help="Enable OpenTelemetry tracing"
+    )
+    parser.add_argument(
+        "--trace_endpoint",
+        type=str,
+        default="http://localhost:4317",
+        help="OpenTelemetry collector endpoint",
+    )
+    parser.add_argument(
+        "--trace_service_name",
+        type=str,
+        default="sagi_tracer",
+        help="Service name for OpenTelemetry tracing",
+    )
     return parser.parse_args()
 
 
 # load env variables
 load_dotenv()
+
+
+def setup_tracing(endpoint: str = None, service_name: str = None):
+    """Setup OpenTelemetry tracing based on args."""
+
+    try:
+        otel_exporter = OTLPSpanExporter(endpoint=endpoint, insecure=True)
+        tracer_provider = TracerProvider(
+            resource=Resource.create({ResourceAttributes.SERVICE_NAME: service_name})
+        )
+        span_processor = BatchSpanProcessor(otel_exporter)
+        tracer_provider.add_span_processor(span_processor)
+        trace.set_tracer_provider(tracer_provider)
+        tracer = trace.get_tracer(service_name)
+        logging.info(f"OpenTelemetry tracing enabled, exporting to {endpoint}")
+        return tracer
+    except Exception as e:
+        logging.error(f"Failed to setup tracing: {e}")
+        return None
 
 
 async def main_cmd(args: argparse.Namespace):
@@ -64,12 +105,13 @@ async def main_cmd(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-    from autogen_agentchat import TRACE_LOGGER_NAME
-
-    # For trace logging.
-    trace_logger = logging.getLogger(TRACE_LOGGER_NAME)
-    trace_logger.addHandler(logging.StreamHandler())
-    trace_logger.setLevel(logging.INFO)
     logging.info("------------- run main async---------------------------------------")
     args = parse_args()
-    asyncio.run(main_cmd(args))
+    if args.trace:
+        tracer = setup_tracing(
+            endpoint=args.trace_endpoint, service_name=args.trace_service_name
+        )
+        with tracer.start_as_current_span("runtime"):
+            asyncio.run(main_cmd(args))
+    else:
+        asyncio.run(main_cmd(args))

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,3 +76,8 @@ autogen-agentchat==0.5.4
 autogen-core==0.5.4
 autogen-ext==0.5.4
 json-schema-to-pydantic==0.2.4
+
+# for using opentelemetry tracing
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc

--- a/workflows/planning.py
+++ b/workflows/planning.py
@@ -146,14 +146,14 @@ class PlanningWorkflow:
                 base_url=config_code_client["base_url"],
                 api_key=config_code_client["api_key"],
                 model_info=model_info,
-                max_tokens=config_reflection_client["max_tokens"],
+                max_tokens=config_code_client["max_tokens"],
             )
         else:
             self.code_model_client = OpenAIChatCompletionClient(
                 model=config_code_client["model"],
                 base_url=config_code_client["base_url"],
                 api_key=config_code_client["api_key"],
-                max_tokens=config_reflection_client["max_tokens"],
+                max_tokens=config_code_client["max_tokens"],
             )
 
     @classmethod


### PR DESCRIPTION
- Add support for tracing and observability which is powered by the [OpenTelemetry](https://opentelemetry.io/)
- You can use any OpenTelemetry-compatible backend to collect and analyze traces.
- For example, first run [Jaeger](https://www.jaegertracing.io/) locally with forwarded address `localhost:16686`:
    ```bash
      docker run -d --name jaeger \
      -e COLLECTOR_OTLP_ENABLED=true \
      -p 16686:16686 \
      -p 4317:4317 \
      -p 4318:4318 \
      jaegertracing/all-in-one:latest
    ```
    Then run the command as below:
    ```bash
      python cli.py --trace --trace_endpoint localhost:4317 --trace_service_name xxx
    ```
    - trace_endpoint: openTelemetry collector endpoint (the ip address where you run backend), default is `http://localhost:4317`
    - trace_service_name: service name for OpenTelemetry tracing, default is "sagi_tracer"
    After that, you can open `localhost:16686` in your browser to view the tracing results as shown below:
    <img width="1903" alt="image" src="https://github.com/user-attachments/assets/d766a9f1-4544-4896-9d4c-b0ca77f3f3f8" />
- Fix some typos

