### PR TITLE
[bugfix] StreamCodeExecutorAgent Output

### DIFF
--- a/src/Sagi/tools/stream_code_executor/stream_code_executor.py
+++ b/src/Sagi/tools/stream_code_executor/stream_code_executor.py
@@ -1,20 +1,20 @@
 from abc import abstractmethod
-from dataclasses import dataclass
-from typing import AsyncGenerator, List, Literal
+from typing import AsyncGenerator, List
 
+from autogen_agentchat.messages import BaseTextChatMessage
 from autogen_core import CancellationToken
 from autogen_core.code_executor import CodeBlock, CodeExecutor, CodeResult
 
 
-@dataclass
-class CodeResultBlock:
-    type: Literal["filename", "stderr", "stdout"]
-    output: str
+class CodeFileMessage(BaseTextChatMessage):
+    code_file: str
+    command: str
+    content: str
 
 
 class StreamCodeExecutor(CodeExecutor):
     @abstractmethod
     async def execute_code_blocks_stream(
         self, code_blocks: List[CodeBlock], cancellation_token: CancellationToken
-    ) -> AsyncGenerator[CodeResultBlock | CodeResult, None]:
+    ) -> AsyncGenerator[CodeFileMessage | CodeResult, None]:
         pass

--- a/src/Sagi/workflows/planning_orchestrator.py
+++ b/src/Sagi/workflows/planning_orchestrator.py
@@ -44,6 +44,7 @@ from autogen_core.models import (
 )
 from pydantic import BaseModel, Field
 
+from Sagi.tools.stream_code_executor.stream_code_executor import CodeFileMessage
 from Sagi.utils.prompt import (
     get_appended_plan_prompt,
     get_final_answer_prompt,
@@ -122,6 +123,8 @@ class PlanningOrchestrator(BaseGroupChatManager):
                 re.sub(r"\s+", " ", f"{topic_type}: {description}").strip() + "\n"
             )
         self._team_description = self._team_description.strip()
+        # TODO: register the new message type in a systematic way
+        self._message_factory.register(CodeFileMessage)
 
     async def reset(self) -> None:
         """Reset the group chat manager."""


### PR DESCRIPTION
1. The current implementation cannot output the `CodeGenerationEvent` with the persist code_file path and command, and then output `CodeExecutionEvent`. Before this PR, we cannot get both `CodeGenerationEvent` and `CodeExecutionEvent` from the [agent response](https://github.com/Kasma-Inc/Sagi/blob/main/src/Sagi/workflows/planning_orchestrator.py#L212-L221). The reason is that [ChatAgentContainer](https://github.com/microsoft/autogen/blob/c26d894c349d766d6c1260fb1ce2103f553703ba/python/packages/autogen-agentchat/src/autogen_agentchat/teams/_group_chat/_chat_agent_container.py#L79-L95) only publish the last `Response` message. This PR add the `CodeGenerationEvent` and `CodeExecutionEvent` to `message.agent_response.inner_messages`, which behaves the same as the mcp tool in the autogen. However, the implementation of this pr is still not a ideal case, since we only get both `CodeGenerationEvent` and `CodeExecutionEvent` at the same time instead of first getting `CodeGenerationEvent` first and then `CodeExecutionEvent`. This issue leaves for the future PR.
2. The previous implementation of the streaming getting the execution results is thread-unsafe and return wrong exit_code with output, I change back to block output, which is acceptable for now.
3. Now we can get the information of the `CodeGenerationEvent` and `CodeExecutionEvent` in https://github.com/Kasma-Inc/Sagi/blob/main/src/Sagi/workflows/planning_orchestrator.py#L212-L221