### PR TITLE
fix: planning logic

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -61,7 +61,7 @@ def parse_args():
 
 
 # load env variables
-load_dotenv()
+load_dotenv(override=True)
 
 
 def setup_tracing(endpoint: str = None, service_name: str = None):

--- a/src/Sagi/workflows/planning.py
+++ b/src/Sagi/workflows/planning.py
@@ -79,7 +79,7 @@ class PlanningWorkflow:
             model_info = None
 
         if model_info is not None:
-            self.model_client = OpenAIChatCompletionClient(
+            self.orchestrator_model_client = OpenAIChatCompletionClient(
                 model=config_orchestrator_client["model"],
                 base_url=config_orchestrator_client["base_url"],
                 api_key=config_orchestrator_client["api_key"],
@@ -87,7 +87,7 @@ class PlanningWorkflow:
                 model_info=model_info,
             )
         else:
-            self.model_client = OpenAIChatCompletionClient(
+            self.orchestrator_model_client = OpenAIChatCompletionClient(
                 model=config_orchestrator_client["model"],
                 base_url=config_orchestrator_client["base_url"],
                 api_key=config_orchestrator_client["api_key"],
@@ -256,7 +256,7 @@ class PlanningWorkflow:
         rag_agent = AssistantAgent(
             name="retrieval_agent",
             description="a retrieval agent that provides relevant information from the internal database.",
-            model_client=self.model_client,
+            model_client=self.orchestrator_model_client,
             tools=hirag_retrival_tools,  # type: ignore
             system_message="You are a information retrieval agent that provides relevant information from the internal database.",
         )
@@ -264,14 +264,14 @@ class PlanningWorkflow:
         # for new feat: domain specific prompt
         domain_specific_agent = AssistantAgent(
             name="prompt_template_expert",
-            model_client=self.model_client,
+            model_client=self.orchestrator_model_client,
             tools=domain_specific_tools,  # type: ignore
             system_message="You are a prompt expert that provides structured templates for different domains.",
         )
 
         general_agent = AssistantAgent(
             name="general_agent",
-            model_client=self.model_client,
+            model_client=self.orchestrator_model_client,
             description="a general agent that provides answer for simple questions.",
             system_message="You are a general AI assistant that provides answer for simple questions.",
         )
@@ -279,7 +279,7 @@ class PlanningWorkflow:
         surfer = AssistantAgent(
             name="web_search",
             description="a web search agent that collect data and relevant information from the web.",
-            model_client=self.model_client,
+            model_client=self.orchestrator_model_client,
             reflect_on_tool_use=True,  # enable llm summary for contents web search returns
             tools=web_search_tools,  # type: ignore
         )
@@ -301,7 +301,7 @@ class PlanningWorkflow:
                 code_executor,
                 general_agent,
             ],  # can utilize rag_agent
-            model_client=self.model_client,
+            orchestrator_model_client=self.orchestrator_model_client,
             planning_model_client=self.planning_model_client,
             reflection_model_client=self.reflection_model_client,
             domain_specific_agent=domain_specific_agent,  # Add this parameter

--- a/src/Sagi/workflows/planning_group_chat.py
+++ b/src/Sagi/workflows/planning_group_chat.py
@@ -26,7 +26,7 @@ class PlanningGroupChat(BaseGroupChat):
     def __init__(
         self,
         participants: List[ChatAgent],
-        model_client: ChatCompletionClient,
+        orchestrator_model_client: ChatCompletionClient,
         *,
         termination_condition: TerminationCondition | None = None,
         max_turns: int | None = None,
@@ -54,7 +54,7 @@ class PlanningGroupChat(BaseGroupChat):
                 "At least one participant is required for MagenticOneGroupChat."
             )
         # Initialize the model clients.
-        self._model_client = model_client
+        self._orchestrator_model_client = orchestrator_model_client
         self._planning_model_client = planning_model_client  # for json plan output
         self._reflection_model_client = (
             reflection_model_client  # for new feat: reflection
@@ -164,7 +164,7 @@ class PlanningGroupChat(BaseGroupChat):
             participant_descriptions=participant_descriptions,
             max_turns=max_turns,
             message_factory=self._message_factory,
-            model_client=self._model_client,
+            orchestrator_model_client=self._orchestrator_model_client,
             output_message_queue=output_message_queue,
             termination_condition=termination_condition,
             emit_team_events=self._emit_team_events,

--- a/tests/test_stream_code_executor_agent.py
+++ b/tests/test_stream_code_executor_agent.py
@@ -86,7 +86,7 @@ print("Hello World")
 
         elif isinstance(result, CodeFileMessage):
             assert result.code_file.endswith(".py")
-            assert result.command.split(" ")[0].endswith("python")
+            assert result.command.split(" ")[0].endswith(("python", "python3"))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Fix the planning logic when invoke `new_step()` method, add a dictionary `_human_feedback` to the plan manager mapping previous plan content to corresponding human feedback for future preference recommendation use.
- Change all the named `model_client` to `orchestrator_model_client` for alignment.
- Fix some redundent codes.
- Handle some edge cases for robustness.