### PR TITLE
Refactor & Fixes

### DIFF
--- a/src/Sagi/workflows/planning.toml
+++ b/src/Sagi/workflows/planning.toml
@@ -28,3 +28,10 @@
     base_url = "${OPENAI_BASE_URL}"
     api_key = "${OPENAI_API_KEY}"
     max_tokens = 16000
+  
+  [model_clients.single_tool_use_client]
+    model = "gpt-4o-mini"
+    base_url = "${OPENAI_BASE_URL}"
+    api_key = "${OPENAI_API_KEY}"
+    max_tokens = 16000
+    parallel_tool_calls = false


### PR DESCRIPTION
- Refactor: optimize state saving, previously the `state.json` would be overwritten each time. Now, a timestamp has been added to ensure it is not overwritten, and each state is saved in the `states` folder, also, making it more human-readable.
- A `single_tool_use_client` with `parallel_tool_calls: false` has been added. This can be assigned to agents that need to avoid having the LLM call multiple tools at once, preventing potential errors.
- The `system_message` has been manually entered for the code executor agent to resolve the issue with the current default prompt being incorrect.
- The initialization of the `hirag mcp tool` has been commented out to prevent unnecessary overhead. When a `rag_agent` is needed, simply uncomment it manually.