### PR TITLE
feat: template-based plan & refactor & fix

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2,7 +2,6 @@ import argparse
 import asyncio
 import logging
 import os
-import uuid
 
 from autogen_agentchat.messages import BaseMessage
 from autogen_agentchat.ui import Console
@@ -15,7 +14,6 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.semconv.resource import ResourceAttributes
 
 from Sagi.utils.logging_utils import setup_logging
-from Sagi.utils.queries import Database
 from Sagi.workflows.planning import PlanningWorkflow
 
 # Create logging directory if it doesn't exist
@@ -51,6 +49,11 @@ def parse_args():
         action="store_true",
         help="List existing session IDs and exit.",
     )
+    parser.add_argument(
+        "--template_work_dir",
+        type=str,
+        help="Specify the template working directory path",
+    )
     return parser.parse_args()
 
 
@@ -83,55 +86,57 @@ def _default_to_text(self) -> str:
 BaseMessage.to_text = _default_to_text
 
 
-DB_URL = os.getenv("POSTGRES_URL_NO_SSL_DEV")
-if not DB_URL:
-    raise RuntimeError("Environment variable POSTGRES_URL_NO_SSL_DEV is not set!")
+# DB_URL = os.getenv("POSTGRES_URL_NO_SSL_DEV")
+# if not DB_URL:
+#     raise RuntimeError("Environment variable POSTGRES_URL_NO_SSL_DEV is not set!")
 
 
 async def main_cmd(args: argparse.Namespace):
 
-    db = Database(DB_URL)
-    await db.init()
+    # db = Database(DB_URL)
+    # await db.init()
 
-    # List sessions and exit
-    if args.list_sessions:
-        sessions = await db.list_sessions()
-        logging.info("Available sessions:", sessions or ["<none>"])
-        await db.close()
-        return
+    # # List sessions and exit
+    # if args.list_sessions:
+    #     sessions = await db.list_sessions()
+    #     logging.info("Available sessions:", sessions or ["<none>"])
+    #     await db.close()
+    #     return
 
-    session_id = args.session_id or str(uuid.uuid4())
-    logging.info(f"use session_id = {session_id!r}")
+    # session_id = args.session_id or str(uuid.uuid4())
+    # logging.info(f"use session_id = {session_id!r}")
 
-    workflow = await PlanningWorkflow.create(args.config)
+    workflow = await PlanningWorkflow.create(
+        args.config, template_work_dir=args.template_work_dir
+    )
 
     # Load previous state
-    try:
-        team_state = await db.load_state(session_id)
-        await workflow.team.load_state(team_state)
-        logging.info(f"Loaded DB state for session {session_id}")
-    except KeyError:
-        logging.info(f"No DB state for session {session_id}; starting fresh")
-        await workflow.team.reset()
-    except Exception as e:
-        logging.error(f"DB load error: {e}")
+    # try:
+    #     team_state = await db.load_state(session_id)
+    #     await workflow.team.load_state(team_state)
+    #     logging.info(f"Loaded DB state for session {session_id}")
+    # except KeyError:
+    #     logging.info(f"No DB state for session {session_id}; starting fresh")
+    #     await workflow.team.reset()
+    # except Exception as e:
+    #     logging.error(f"DB load error: {e}")
 
     try:
         while True:
             user_input = input("User: ")
             if user_input.lower() in ("quit", "exit", "q"):
                 state = await workflow.team.save_state()
-                await db.save_state(session_id, state)
-                logging.info(f"Saved DB state before exit for {session_id}")
+                # await db.save_state(session_id, state)
+                # logging.info(f"Saved DB state before exit for {session_id}")
                 break
 
             await asyncio.create_task(Console(workflow.run_workflow(user_input)))
             state = await workflow.team.save_state()
-            await db.save_state(session_id, state)
-            logging.info(f"Saved DB state for {session_id}")
+            # await db.save_state(session_id, state)
+            # logging.info(f"Saved DB state for {session_id}")
     finally:
         await workflow.cleanup()
-        await db.close()
+        # await db.close()
         logging.info("Workflow cleaned up.")
 
 

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -32,7 +32,7 @@ start_docker_compose() {
 
     # start docker-compose
     echo "Starting docker-compose with project name: ${COMPOSE_PROJECT_NAME}..."
-    docker-compose -f docker-compose.yml -p ${COMPOSE_PROJECT_NAME} up -d --build
+    docker compose -f docker-compose.yml -p ${COMPOSE_PROJECT_NAME} up -d --build
     if [ $? -ne 0 ]; then
         echo "docker-compose failed to start. Please check the logs for more information."
         exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   markify:
     image: sagicuhk/markify:latest
-    container_name: "${USERNAME}_markify_service"
+    container_name: "${USERNAME}_markify_service_test"
     entrypoint: ["/bin/sh", "/root/preprocess.sh"]  # just restart to update quickly without rebuilding
     ports:
       - "20926"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   markify:
     image: sagicuhk/markify:latest
-    container_name: "${USERNAME}_markify_service_test"
+    container_name: "${USERNAME}_markify_service"
     entrypoint: ["/bin/sh", "/root/preprocess.sh"]  # just restart to update quickly without rebuilding
     ports:
       - "20926"

--- a/src/Sagi/mcp_server/domain_specific_mcp/src/domain_specific_mcp/prompt_template.py
+++ b/src/Sagi/mcp_server/domain_specific_mcp/src/domain_specific_mcp/prompt_template.py
@@ -31,10 +31,10 @@ USER QUERY: {task}
 You are a professional planning assistant. 
 Based on the team composition, user query, and known and unknown facts, please devise a plan for addressing the USER QUERY. Remember, there is no requirement to involve all team members -- a team member particular expertise may not be needed for this task.
 
-Each plan step should contain the following elements:
-1. name: A short title for this step
-2. description: Detailed explanation of the step objective and financial content
-3. data_collection_task: Specific instructions for gathering financial data needed for this step (optional)
+Each plan group should contain the following elements:
+1. name: A short title for this group task
+2. description: Detailed explanation of the group objective.
+3. data_collection_task: Specific instructions for gathering data needed for this group task (optional)
 4. code_executor_task: Description of what code executor should do, JUST DETAILED DESCRIPTION IS OK, NOT ACTUAL CODE BLOCK.(optional)
 """
 
@@ -68,14 +68,14 @@ USER QUERY: {task}
 You are a professional financial PPT creation planning assistant. 
 Based on the team composition, user query, please generate a detailed financial PowerPoint presentation creation plan following these structural requirements:
 
-Each plan step should contain the following elements:
-1. name: A short title for this step
-2. description: Detailed explanation of the step objective and financial content
-3. data_collection_task: Specific instructions for gathering financial data needed for this step (optional)
+Each plan group should contain the following elements:
+1. name: A short title for this group task
+2. description: Detailed explanation of the group objective and financial content
+3. data_collection_task: Specific instructions for gathering financial data needed for this group task (optional)
 4. code_executor_task: Description of what code should do to process data, GENERATE slide, APPEND it to PPT and SAVE PPT (optional)
 
 Plan requirements:
-- Each step should GENERATE one slide, APPEND it to the PPT and SAVE PPT.
+- Each group task should GENERATE one slide, APPEND it to the PPT and SAVE PPT.
 - Include common financial PPT elements such as titles, financial metrics, bullet point lists, visual elements (charts, graphs, financial tables, etc.)
 - Code sections should primarily use Python (with visualization libraries like matplotlib, seaborn, plotly, pandas_datareader, etc.) or bash to install dependencies
 - Ensure code is practical and executable, capable of completing financial data processing and slide generation tasks
@@ -83,17 +83,17 @@ Plan requirements:
 
 Please output in JSON format, conforming to the following structure:
 
-  steps: [
-      name: Step Name,
-      description: Step Description,
+  groups: [
+      name: Group Task Name,
+      description: Group Task Description,
       data_collection_task: Data Collection Task Description,
       code_executor_task: Description of code task to be performed based on the collected data
     ,
-    ...more steps
+    ...more groups
   ]
 
 Example for a Tesla stock analysis presentation:
-  steps: [
+  groups: [
       name: Company Overview,
       description: Create a title slide with brief overview of Tesla, including its ticker symbol, industry, and founding date.,
       data_collection_task: Find Tesla ticker symbol (TSLA), founding date, headquarters location, and CEO information.,
@@ -121,7 +121,7 @@ Example for a Tesla stock analysis presentation:
       code_executor_task: Create a final slide with a clear investment recommendation (Buy/Hold/Sell) in large, colored text. Include a target price with potential upside percentage. Add bullet points outlining the key investment thesis including growth potential, technological advantages, and potential risks. Format the slide professionally with consistent fonts and colors. Remember to append the slide to PPT and save PPT.
   ]
 
-REMEMBER: EACH STEP MUST SAVE THE PPT AFTER APPENDING THE SLIDE.
+REMEMBER: EACH GROUP TASK MUST SAVE THE PPT AFTER APPENDING THE SLIDE.
 """
 
 GENERAL_PPT_PLAN_PROMPT = """Excellent. To create the presentation outlined in the request, we have assembled the following team:
@@ -133,28 +133,28 @@ USER QUERY: {task}
 You are a professional PPT creation planning assistant. 
 Based on the team composition, user query, please generate a detailed PowerPoint presentation creation plan following these structural requirements:
 
-Each plan step should contain the following elements:
-1. name: A short title for this step
-2. description: Detailed explanation of the step objective and content
-3. data_collection_task: Specific instructions for gathering data needed for this step (optional)
+Each plan group should contain the following elements:
+1. name: A short title for this group task
+2. description: Detailed explanation of the group objective and content
+3. data_collection_task: Specific instructions for gathering data needed for this group task (optional)
 4. code_executor_task: Description of what code should do to process data, GENERATE slide, APPEND it to PPT and SAVE PPT (optional)
 
 Plan requirements:
-- Each step should GENERATE one slide, APPEND it to the PPT and SAVE PPT.
+- Each group task should GENERATE one slide, APPEND it to the PPT and SAVE PPT.
 - Include common PPT elements such as titles, body text, bullet point lists, visual elements (charts, images, etc.)
 - Code tasks should describe operations to be performed using Python (with visualization libraries like matplotlib, seaborn, plotly, etc.) or bash to install dependencies
 - Code task descriptions should be clear enough to guide future code generation based on the collected data
 
 Please output in JSON format, conforming to the following structure:
 
-  steps: [
-      name: Step Name,
-      description: Step Description,
+  groups: [
+      name: Group Task Name,
+      description: Group Task Description,
       data_collection_task: Data Collection Task Description,
       code_executor_task: Description of code task to be performed based on the collected data
     ,
-    ...more steps
+      ...more groups
   ]
 
-REMEMBER: EACH STEP MUST SAVE THE PPT AFTER APPENDING THE SLIDE.
+REMEMBER: EACH GROUP TASK MUST SAVE THE PPT AFTER APPENDING THE SLIDE.
 """

--- a/src/Sagi/templates/test_work_dir/file_content.json
+++ b/src/Sagi/templates/test_work_dir/file_content.json
@@ -1,0 +1,776 @@
+{
+    "image_dir": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis",
+    "sections": [
+        {
+            "title": "Overview",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Apple Offer",
+                    "content": "Get $180–$650 in credit toward iPhone 16 or iPhone 16 Pro when you trade in iPhone 12 or higher.",
+                    "medias": []
+                },
+                {
+                    "title": "Apple Intelligence",
+                    "content": "Apple Intelligence available now\n\nApple Intelligence 现已推出",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "Get the highlights.",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Film Introduction",
+                    "content": "**The first iPhone built** 第⼀部 **iPhone** 诞⽣ **for Apple Intelligence.** 对于苹 **果情报。 Personal, private, 个⼈的、私⼈** 的、 **powerful. 强⼤的。 <** )",
+                    "medias": []
+                },
+                {
+                    "title": "Closer Look",
+                    "content": "![](_page_0_Picture_5.jpeg)",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "Strength. Beauty. Titanium.",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Design and Materials",
+                    "content": "iPhone 16 Pro features a Grade 5 titanium design with a new, refined microblasted texture. Titanium has one of the highest strength-to-weight ratios of any metal, making these models incredibly strong and impressively light. iPhone 16 Pro comes in four stunning finishes — including new Desert Titanium. iPhone 16 Pro 采⽤ 5 级钛⾦属设计, 具有全新精致的微喷砂纹理。钛是所有 ⾦属中强度重量⽐最⾼的⾦属之⼀,使 这些模型变得异常坚固且极其轻盈。 iPhone 16 Pro 拥有四种令⼈惊叹的饰 ⾯,包括全新的 Desert Titanium。",
+                    "medias": [
+                        {
+                            "markdown_content": "![](_page_0_Picture_11.jpeg)",
+                            "near_chunks": [
+                                "**gaming — for longer. 内部设计改进**——包括 **100% 再⽣铝制 散热结构和进⼀步散热的背⾯玻璃优化** ——**使持续性能⽐ iPhone 15 Pro** 提⾼ 了 **20%。因此,您可以更⻓时间地做所 有您喜欢的事情,例如⾼强度游戏。**\n\n**Internal design improvements including a 100 percent recycled aluminum thermal substructure and back glass optimizations that further dissipate heat — enable up to 20 percent better sustained performance than iPhone 15 Pro. So you can do all the things you love — like high-intensity**\n\n",
+                                "**Premium Grade 5 titanium is**\n\n**Premium Grade 5 titanium is**\n\n**exceptionally durable**\n\n**exceptionally durable**\n\n优质 5 **级钛⾦属⾮常耐⽤**\n\n优质 5 **级钛⾦属⾮常耐⽤**\n\n**New display technology allows us to route display data under active pixels with no distortion, resulting in thinner borders for larger 6.3-inch and 6.9-inch Super Retina XDR displays that feel great in your hand.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_0_Picture_11.jpeg",
+                            "caption": "Picture: Two smartphones with sleek designs and curved edges. They feature a dark theme and reflective surfaces, showcasing a modern aesthetic against a black background."
+                        },
+                        {
+                            "markdown_content": "![](_page_0_Figure_12.jpeg)",
+                            "near_chunks": [
+                                "**gaming — for longer. 内部设计改进**——包括 **100% 再⽣铝制 散热结构和进⼀步散热的背⾯玻璃优化** ——**使持续性能⽐ iPhone 15 Pro** 提⾼ 了 **20%。因此,您可以更⻓时间地做所 有您喜欢的事情,例如⾼强度游戏。**\n\n**Internal design improvements including a 100 percent recycled aluminum thermal substructure and back glass optimizations that further dissipate heat — enable up to 20 percent better sustained performance than iPhone 15 Pro. So you can do all the things you love — like high-intensity**\n\n",
+                                "**Premium Grade 5 titanium is**\n\n**Premium Grade 5 titanium is**\n\n**exceptionally durable**\n\n**exceptionally durable**\n\n优质 5 **级钛⾦属⾮常耐⽤**\n\n优质 5 **级钛⾦属⾮常耐⽤**\n\n**New display technology allows us to route display data under active pixels with no distortion, resulting in thinner borders for larger 6.3-inch and 6.9-inch Super Retina XDR displays that feel great in your hand.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_0_Figure_12.jpeg",
+                            "caption": "Picture: Close-up of a smartphone home screen displaying weather, calendar, and various app icons on a dark-themed interface, with time and connectivity icons at the top."
+                        }
+                    ]
+                },
+                {
+                    "title": "Internal Improvements",
+                    "content": "Internal design improvements including a 100 percent recycled aluminum thermal substructure and back glass optimizations that further dissipate heat — enable up to 20 percent better sustained performance than iPhone 15 Pro. So you can do all the things you love — like high-intensity gaming — for longer. 内部设计改进——包括 100% 再⽣铝制 散热结构和进⼀步散热的背⾯玻璃优化 ——使持续性能⽐ iPhone 15 Pro 提⾼ 了 20%。因此,您可以更⻓时间地做所 有您喜欢的事情,例如⾼强度游戏。",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "Camera Control",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Overview",
+                    "content": "Now you can take the perfect photo or video in record time. Camera Control gives you an easier way to quickly access camera tools. Simply slide your finger to adjust camera functions like exposure or depth of field, and toggle through each lens or use digital zoom to frame your shot — just how you like it.",
+                    "medias": [
+                        {
+                            "markdown_content": "![](_page_0_Picture_39.jpeg)",
+                            "near_chunks": [
+                                "**How to use Camera Control**\n\n**Camera Control features a two-stage shutter that lets you automatically lock focus and exposure with a light press so you can reframe your shot without losing focus on your subject.**\n\n**Now you can take the perfect photo or video in record time. Camera Control gives you an easier way to quickly access camera tools. Simply slide your finger to adjust camera functions like exposure or depth of field, and toggle through each lens or use digital zoom to frame your shot — just how you like it.**\n\n",
+                                "**Click and hold to start recording video. A light press opens controls like zoom.**\n\n**Click to launch the Camera app. Click again to instantly take a photo.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_0_Picture_39.jpeg",
+                            "caption": "Icon: Minimalist play button icon in a grey box located at the bottom right corner."
+                        }
+                    ]
+                },
+                {
+                    "title": "Features",
+                    "content": "Camera Control features a two-stage shutter that lets you automatically lock focus and exposure with a light press so you can reframe your shot without losing focus on your subject.",
+                    "medias": []
+                },
+                {
+                    "title": "Usage Instructions",
+                    "content": "How to use Camera Control\n\nClick and hold to start recording video. A light press opens controls like zoom.\n\nClick to launch the Camera app. Click again to instantly take a photo.",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "4K 120 fps Dolby Vision",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Video Capture",
+                    "content": "iPhone 16 Pro takes video capture to a whole new level with 4K 120 fps Dolby Vision — our highest resolution and frame rate combo yet. Enabled by the new 48MP Fusion camera with second-generation quad-pixel sensor and our powerful A18 Pro chip, iPhone 16 Pro lets you record 4K 120 fps Dolby Vision in video mode or slo-mo.",
+                    "medias": []
+                },
+                {
+                    "title": "Editing Capabilities",
+                    "content": "And now you can adjust the playback speed after capture in the redesigned Photos app, giving you greater editing capabilities. To add a dreamy quality to your shot, try out the new half-speed option. Or for a cinematic effect, slow it right down to 24 fps playback.",
+                    "medias": []
+                },
+                {
+                    "title": "Audio Performance",
+                    "content": "iPhone 16 Pro also provides a big leap in audio performance with four studio-quality mics for higher-quality recording. They provide a lower noise floor so you get more true-to-life sounds. New Spatial Audio capture makes your videos sound more immersive when listening with AirPods. And thanks to wind noise reduction, the audio quality is even clearer.",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "Audio Mix Features",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Overview",
+                    "content": "Powered by advanced intelligence and Spatial Audio capture, Audio Mix lets you adjust the way voices sound in your videos using three different voice options. Want to decrease background sound? Or just focus on the voices that are in frame? Simply select the mix and adjust intensity to get the sound you want after video capture.",
+                    "medias": [
+                        {
+                            "markdown_content": "![](_page_1_Picture_8.jpeg)",
+                            "near_chunks": [
+                                "**Powered by advanced intelligence and Spatial Audio capture, Audio Mix lets you adjust the way voices sound in your videos using three different voice options. Want to decrease background sound? Or just focus on the voices that are in frame? Simply select the mix and adjust intensity to get the sound you want after video capture.**\n\n",
+                                "#### **In-frame**\n\n**Only captures the voices of the people on camera, even if people off-camera are talking during the recording.**\n\n#### **Studio**\n\n**Makes voices sound like you're recording in a professional studio equipped with sound-dampening walls. Great for vloggers or podcasters because the recording will sound like the mic is close to the subject's mouth, even if it's a few feet away.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_1_Picture_8.jpeg",
+                            "caption": "Picture: Two people sitting at a table using a phone's audio mix feature labeled \"IN-FRAME,\" with options \"STANDARD,\" \"STUDIO,\" and \"CINEMATIC\" visible."
+                        }
+                    ]
+                },
+                {
+                    "title": "In-frame",
+                    "content": "Only captures the voices of the people on camera, even if people off-camera are talking during the recording.",
+                    "medias": []
+                },
+                {
+                    "title": "Studio",
+                    "content": "Makes voices sound like you're recording in a professional studio equipped with sound-dampening walls. Great for vloggers or podcasters because the recording will sound like the mic is close to the subject's mouth, even if it's a few feet away.",
+                    "medias": []
+                },
+                {
+                    "title": "Cinematic",
+                    "content": "Captures all of the voices around you and consolidates them toward the front of the screen — just like sound is formatted for the movies.",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "Shot on iPhone 16 Pro",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Introduction",
+                    "content": "Go behind the scenes of The Weeknd's groundbreaking music video to learn how the powerful camera features on iPhone 16 Pro deliver more creative freedom and flexibility than ever before. The \"Dancing in the Flames\" cinematographer Erik Henriksson films the video in dreamlike slow motion using 4K 120 fps Dolby Vision on iPhone 16 Pro. Thanks to Camera Control, he could make technical decisions by simply sliding a finger to adjust camera functions like exposure or focal length — all without missing a beat.",
+                    "medias": [
+                        {
+                            "markdown_content": "![](_page_1_Picture_17.jpeg)",
+                            "near_chunks": [
+                                "**Go behind the scenes of The Weeknd's groundbreaking music video to learn how the powerful camera features on iPhone 16 Pro deliver more creative freedom and flexibility than ever before. The \"Dancing in the Flames\" cinematographer Erik Henriksson films the video in dreamlike slow motion using 4K 120 fps Dolby Vision on iPhone 16 Pro. Thanks to Camera Control, he could make technical decisions by simply sliding a finger to adjust camera functions like exposure or focal length — all without missing a beat.**\n\n",
+                                "**iPhone 16 Pro adds a second 48MP camera to the Pro camera system. The new 48MP Ultra Wide camera has a more advanced quad-pixel sensor for super-high-resolution 48MP ProRAW and HEIF photos with autofocus.**\n\n**So you can capture a mesmerizing new level of detail in macro photos and sweeping, wide-angle shots.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_1_Picture_17.jpeg",
+                            "caption": "Picture: A person in sunglasses is being filmed by a smartphone camera, held within a stabilizing rig, under moody and atmospheric lighting."
+                        },
+                        {
+                            "markdown_content": "![](_page_1_Picture_18.jpeg)",
+                            "near_chunks": [
+                                "**Go behind the scenes of The Weeknd's groundbreaking music video to learn how the powerful camera features on iPhone 16 Pro deliver more creative freedom and flexibility than ever before. The \"Dancing in the Flames\" cinematographer Erik Henriksson films the video in dreamlike slow motion using 4K 120 fps Dolby Vision on iPhone 16 Pro. Thanks to Camera Control, he could make technical decisions by simply sliding a finger to adjust camera functions like exposure or focal length — all without missing a beat.**\n\n",
+                                "**iPhone 16 Pro adds a second 48MP camera to the Pro camera system. The new 48MP Ultra Wide camera has a more advanced quad-pixel sensor for super-high-resolution 48MP ProRAW and HEIF photos with autofocus.**\n\n**So you can capture a mesmerizing new level of detail in macro photos and sweeping, wide-angle shots.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_1_Picture_18.jpeg",
+                            "caption": "Banner: Promotional text for a new 48MP Ultra Wide camera, emphasizing resolution."
+                        },
+                        {
+                            "markdown_content": "![](_page_1_Picture_21.jpeg)",
+                            "near_chunks": [
+                                "**So you can capture a mesmerizing new level of detail in macro photos and sweeping, wide-angle shots.**\n\n**iPhone 16 Pro adds a second 48MP camera to the Pro camera system. The new 48MP Ultra Wide camera has a more advanced quad-pixel sensor for super-high-resolution 48MP ProRAW and HEIF photos with autofocus.**\n\n",
+                                "Macro 13 mm 24 mm 28 mm 35 mm 48 mm 120 mm\n\n**0.5x Ultra Wide**\n\n**More zoom? Boom. Now you can shoot in 120 mm with the 5x Telephoto camera on both Pro models and get sharper close-ups from farther away. With multiple framing options, it's like having seven pro lenses in your pocket, everywhere you go.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_1_Picture_21.jpeg",
+                            "caption": "Picture: Expansive landscape featuring barren rocky terrain, grassy patches, and mountainous backdrop. Cloudy and vivid blue sky above."
+                        },
+                        {
+                            "markdown_content": "![](_page_1_Picture_28.jpeg)",
+                            "near_chunks": [
+                                "> **Choose your Photographic Style. Change it up. Change it back.**\n\n**More zoom? Boom. Now you can shoot in 120 mm with the 5x Telephoto camera on both Pro models and get sharper close-ups from farther away. With multiple framing options, it's like having seven pro lenses in your pocket, everywhere you go.**\n\n",
+                                "**Our latest generation of Photographic Styles gives you greater creative flexibility than ever before, so you can make every photo even more you. And thanks to advances in our image pipeline, you can now reverse any style, anytime.**\n\n### **Lock in your look.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_1_Picture_28.jpeg",
+                            "caption": "Picture: Person in a pink outfit stands in a grassy, rocky landscape with dramatic mountains in the background under a cloudy sky."
+                        },
+                        {
+                            "markdown_content": "![](_page_1_Picture_30.jpeg)",
+                            "near_chunks": [
+                                "**Our latest generation of Photographic Styles gives you greater creative flexibility than ever before, so you can make every photo even more you. And thanks to advances in our image pipeline, you can now reverse any style, anytime.**\n\n> **Choose your Photographic Style. Change it up. Change it back.**\n\n",
+                                "### **Lock in your look.**\n\n**We've created new styles that let you dial in your exact desired look with more advanced skin-tone rendering and set it across your photos.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_1_Picture_30.jpeg",
+                            "caption": "Picture: Smartphone screen displaying photo style options. Four images show a person in a pink outfit against different natural backgrounds. Text below describes the standard camera look as balanced and true-to-life."
+                        },
+                        {
+                            "markdown_content": "![](_page_2_Picture_0.jpeg)",
+                            "near_chunks": [
+                                "**We've created new styles that let you dial in your exact desired look with more advanced skin-tone rendering and set it across your photos.**\n\n### **Lock in your look.**\n\n**Our latest generation of Photographic Styles gives you greater creative flexibility than ever before, so you can make every photo even more you. And thanks to advances in our image pipeline, you can now reverse any style, anytime.**\n\n",
+                                ""
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_2_Picture_0.jpeg",
+                            "caption": "Logo: Apple logo with \"A18 PRO\" text, featuring a metallic design on a dark background."
+                        }
+                    ]
+                },
+                {
+                    "title": "Camera Features",
+                    "content": "iPhone 16 Pro adds a second 48MP camera to the Pro camera system. The new 48MP Ultra Wide camera has a more advanced quad-pixel sensor for super-high-resolution 48MP ProRAW and HEIF photos with autofocus. So you can capture a mesmerizing new level of detail in macro photos and sweeping, wide-angle shots.",
+                    "medias": []
+                },
+                {
+                    "title": "Zoom Capabilities",
+                    "content": "More zoom? Boom. Now you can shoot in 120 mm with the 5x Telephoto camera on both Pro models and get sharper close-ups from farther away. With multiple framing options, it's like having seven pro lenses in your pocket, everywhere you go.",
+                    "medias": []
+                },
+                {
+                    "title": "Photographic Styles",
+                    "content": "Choose your Photographic Style. Change it up. Change it back. Our latest generation of Photographic Styles gives you greater creative flexibility than ever before, so you can make every photo even more you. And thanks to advances in our image pipeline, you can now reverse any style, anytime.",
+                    "medias": []
+                },
+                {
+                    "title": "Custom Looks",
+                    "content": "Lock in your look. We've created new styles that let you dial in your exact desired look with more advanced skin-tone rendering and set it across your photos.",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "A18 Pro Chip Overview",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Introduction",
+                    "content": "A phenomenally powerful chip, A18 Pro enables Apple Intelligence with a faster Neural Engine, an improved CPU and GPU, and a big jump in memory bandwidth. It also drives advanced video and photo features like Camera Control, and it delivers our best-ever graphics performance for AAA gaming.",
+                    "medias": [
+                        {
+                            "markdown_content": "![](_page_2_Figure_9.jpeg)",
+                            "near_chunks": [
+                                "**17% increase in total system memory bandwidth, the highest ever in iPhone, for outstanding performance**\n\n**New 6-core GPU gives you enhanced graphics performance**\n\n**the fastest in a smartphone, runs complex workloads with less power**\n\n#### **New 6-core CPU,**\n\n",
+                                "DEATH STRANDING DIRECTOR'S CUT\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_2_Figure_9.jpeg",
+                            "caption": "Chart: Comparison of 6-core CPU and GPU performance between an unspecified model and iPhone 12 Pro, featuring bars to indicate enhancement levels."
+                        },
+                        {
+                            "markdown_content": "![](_page_2_Picture_11.jpeg)",
+                            "near_chunks": [
+                                "DEATH STRANDING DIRECTOR'S CUT\n\n**17% increase in total system memory bandwidth, the highest ever in iPhone, for outstanding performance**\n\n**New 6-core GPU gives you enhanced graphics performance**\n\n**the fastest in a smartphone, runs complex workloads with less power**\n\n",
+                                ""
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_2_Picture_11.jpeg",
+                            "caption": "Picture: A person carrying a large backpack traverses a lush, mountainous landscape with waterfalls and rocky terrain."
+                        },
+                        {
+                            "markdown_content": "![](_page_2_Picture_12.jpeg)",
+                            "near_chunks": [
+                                "DEATH STRANDING DIRECTOR'S CUT\n\n**17% increase in total system memory bandwidth, the highest ever in iPhone, for outstanding performance**\n\n**New 6-core GPU gives you enhanced graphics performance**\n\n**the fastest in a smartphone, runs complex workloads with less power**\n\n",
+                                ""
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_2_Picture_12.jpeg",
+                            "caption": "Picture: Close-up of a black gaming controller with illuminated accents, featuring familiar control buttons."
+                        }
+                    ]
+                },
+                {
+                    "title": "Neural Engine",
+                    "content": "New 16-core Neural Engine is faster and more efficient, supercharging Apple Intelligence",
+                    "medias": []
+                },
+                {
+                    "title": "CPU and GPU",
+                    "content": "New 6-core CPU, the fastest in a smartphone, runs complex workloads with less power\nNew 6-core GPU gives you enhanced graphics performance",
+                    "medias": []
+                },
+                {
+                    "title": "Memory Bandwidth",
+                    "content": "17% increase in total system memory bandwidth, the highest ever in iPhone, for outstanding performance",
+                    "medias": []
+                },
+                {
+                    "title": "Graphics Examples",
+                    "content": "DEATH STRANDING DIRECTOR'S CUT",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "In a whole new light",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Lifelike Gaming",
+                    "content": "With up to two times faster hardware-accelerated ray tracing, A18 Pro makes games look and feel beautifully lifelike — with more fluid graphics and realistic lighting. And with Game Mode in iOS 18, you'll get better sustained frame rates for continuous play and improved responsiveness if you're using wireless controllers and AirPods. Up to 2x faster hardware-accelerated ray tracing than A17 Pro",
+                    "medias": [
+                        {
+                            "markdown_content": "![](_page_2_Picture_22.jpeg)",
+                            "near_chunks": [
+                                "**Up to 27 hours video playback on iPhone 16 Prog**\n\n**Up to 33 hours video playback on iPhone 16 Pro Maxg**\n\n**Snap on a new MagSafe charger for even faster wireless charging — up to 25W with a 30W power adapter or higher, enabling up to 50% charge in around 30 minutes.** i j\n\n",
+                                ""
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_2_Picture_22.jpeg",
+                            "caption": "Picture: A spacecraft in orbit against a planetary background, featuring the text \"For All Mankind\" and the Apple TV+ logo."
+                        },
+                        {
+                            "markdown_content": "| Compare with | iPhone 12 Pro |  |\n| --- | --- | --- |\n| Up to |  | Up to |\n| 10 more hours 10 more hours |  | 16 more hours 16 more hours |\n| video playback on iPhone 16 Pro |  | video playback on iPhone 16 Pro Max |",
+                            "near_chunks": [
+                                "**Up to 27 hours video playback on iPhone 16 Prog**\n\n**Up to 33 hours video playback on iPhone 16 Pro Maxg**\n\n**Snap on a new MagSafe charger for even faster wireless charging — up to 25W with a 30W power adapter or higher, enabling up to 50% charge in around 30 minutes.** i j\n\n",
+                                ""
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/table_ff7b.png",
+                            "caption": "Table: Comparison of additional video playback hours between the iPhone 12 Pro and the iPhone 16 models, highlighting up to 10 more hours for the iPhone 16 Pro and up to 16 more hours for the iPhone 16 Pro Max.",
+                            "cells": [
+                                [
+                                    "Compare with",
+                                    "iPhone 12 Pro",
+                                    ""
+                                ],
+                                [
+                                    "Up to",
+                                    "",
+                                    "Up to"
+                                ],
+                                [
+                                    "10 more hours 10 more hours",
+                                    "",
+                                    "16 more hours 16 more hours"
+                                ],
+                                [
+                                    "video playback on iPhone 16 Pro",
+                                    "",
+                                    "video playback on iPhone 16 Pro Max"
+                                ]
+                            ],
+                            "merge_area": null
+                        }
+                    ]
+                },
+                {
+                    "title": "Battery Life Advancements",
+                    "content": "iPhone 16 Pro gives you longer battery life — and iPhone 16 Pro Max delivers the best battery life ever on an iPhone. How? An optimized internal design fits larger batteries, which work together with the A18 Pro chip to deliver incredibly power-efficient performance. Even with so many new capabilities. Snap on a new MagSafe charger for even faster wireless charging — up to 25W with a 30W power adapter or higher, enabling up to 50% charge in around 30 minutes. Up to 33 hours video playback on iPhone 16 Pro Max Up to 27 hours video playback on iPhone 16 Pro",
+                    "medias": []
+                },
+                {
+                    "title": "Comparison with iPhone 12 Pro",
+                    "content": "| Compare with | iPhone 12 Pro |  |\n| --- | --- | --- |\n| Up to |  | Up to |\n| 10 more hours 10 more hours |  | 16 more hours 16 more hours |\n| video playback on iPhone 16 Pro |  | video playback on iPhone 16 Pro Max |",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "iOS 18 Features",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Home Screen Personalization",
+                    "content": "Personalize your Home Screen. Tint your icons with any color. Rearrange and resize apps and widgets. You can even lock or hide apps to protect sensitive information — it's your call.",
+                    "medias": []
+                },
+                {
+                    "title": "Control Customization",
+                    "content": "Choose your controls. Swap out your Lock Screen controls for ones you love to use more often. Or you can assign a control to the Action button.",
+                    "medias": []
+                },
+                {
+                    "title": "Photos App Redesign",
+                    "content": "Find your favorite shots faster. In the redesigned Photos app, your Collections are automatically organized by topic, like People & Pets.",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "Satellite Connectivity Features",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Satellite Messaging",
+                    "content": "When you don't have cell service or Wi-Fi, iPhone 16 Pro can connect you to a satellite, so you can stay in touch or get the assistance you need. Messages via satellite lets you send and receive messages and Tapbacks when you're off the grid, right from the Messages app. Your iPhone will help you connect to a satellite, so you can text over iMessage or SMS.",
+                    "medias": []
+                },
+                {
+                    "title": "Roadside Assistance",
+                    "content": "Roadside Assistance via satellite can get you help for things like a flat tire or a dead car battery. iPhone will connect you with a roadside assistance provider, who can dispatch help to your exact location — even if you're off the grid. See how Roadside Assistance works. Roadside Assistance via satellite is included for free for two years with iPhone 16 Pro.",
+                    "medias": []
+                },
+                {
+                    "title": "Emergency Features",
+                    "content": "iPhone also has vital safety features that can help save lives. If you try calling 911 for urgent help but don't have cell service or Wi-Fi, you can use iPhone to text emergency services over satellite. See how Emergency SOS via satellite works. Crash Detection uses hardware sensors and advanced motion algorithms to detect a severe car crash, then call 911 and notify your emergency contacts when you can't — even when you don't have service. When you're within range and make a 911 emergency call, iPhone 16 Pro gives you the option to start sharing a live feed with 911 responders for quick and effective assistance.",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        },
+        {
+            "title": "Designed to make a difference",
+            "summary": "The document highlights the environmentally conscious design of the iPhone 16 Pro, emphasizing the use of 100% renewable electricity in Apple data centers and increased utilization of recycled materials, including lithium, gold, and copper, in its components. The iPhone 16 Pro also features 100% fiber-based packaging. Privacy is prioritized with features like on-device processing and end-to-end encrypted password management. Accessibility enhancements include Eye Tracking for navigation and Music Haptics for deaf users. Integration across Apple devices is seamless, with features like iPhone Mirroring and Continuity for ease of use. Various purchasing and financing options are available through Apple, with special offers from carriers for trading in old phones.",
+            "subsections": [
+                {
+                    "title": "Environment",
+                    "content": "All Apple data centers, including those that power Apple Intelligence, run on 100% renewable electricity. iPhone 16 Pro uses more recycled metals than ever: over 95% recycled lithium in the battery, 100% recycled gold in the plating of the USB-C connector and camera wires, and 100% recycled copper foil in the MagSafe inductive charger. The packaging for iPhone 16 Pro is 100% fiber-based for the first time and is thinner, reducing the carbon impact for shipping.",
+                    "medias": [
+                        {
+                            "markdown_content": "![](_page_2_Picture_49.jpeg)",
+                            "near_chunks": [
+                                "**over 95% recycled lithium in the battery. 100% recycled gold in the plating of the USB-C connector and camera wires. 100% recycled copper foil in the MagSafe inductive charger.** mp\n\n**iPhone 16 Pro uses more recycled metals than ever:**\n\n**renewable electricity.**\n\n",
+                                "**The packaging for iPhone 16 Pro is 100% fiber based for the first time. And it's thinner, which reduces the carbon impact for shipping.** mT mh\n\n**Learn about Apple and the environment**\n\n### **Privacy**\n\n**Apple Intelligence protects your privacy at every step. With ondevice processing and Private Cloud Compute, no one but you can access your data — not even Apple.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_2_Picture_49.jpeg",
+                            "caption": "Logo: Apple logo in black, featuring a stylized apple with a bite on the right side and a leaf on top."
+                        },
+                        {
+                            "markdown_content": "![](_page_2_Figure_53.jpeg)",
+                            "near_chunks": [
+                                "### **Privacy**\n\n**Learn about Apple and the environment**\n\n**The packaging for iPhone 16 Pro is 100% fiber based for the first time. And it's thinner, which reduces the carbon impact for shipping.** mT mh\n\n**over 95% recycled lithium in the battery. 100% recycled gold in the plating of the USB-C connector and camera wires. 100% recycled copper foil in the MagSafe inductive charger.** mp\n\n",
+                                "**Apple Intelligence protects your privacy at every step. With ondevice processing and Private Cloud Compute, no one but you can access your data — not even Apple.**\n\n**The new Passwords app makes it even easier to access account passwords, passkeys, Wi-Fi passwords, twofactor authentication codes, and more. It stores them securely and syncs across your**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_2_Figure_53.jpeg",
+                            "caption": "Logo: Simple apple silhouette with a bite taken out on the right side."
+                        },
+                        {
+                            "markdown_content": "![](_page_2_Picture_55.jpeg)",
+                            "near_chunks": [
+                                "**Apple Intelligence protects your privacy at every step. With ondevice processing and Private Cloud Compute, no one but you can access your data — not even Apple.**\n\n### **Privacy**\n\n**Learn about Apple and the environment**\n\n**The packaging for iPhone 16 Pro is 100% fiber based for the first time. And it's thinner, which reduces the carbon impact for shipping.** mT mh\n\n",
+                                "**The new Passwords app makes it even easier to access account passwords, passkeys, Wi-Fi passwords, twofactor authentication codes, and more. It stores them securely and syncs across your**\n\n**devices with end-to-end**\n\n**You can also control which contacts to share with an app, rather than giving it access to all your contacts. And you can choose to share more contacts over time.** **devices with end-to-end encryption.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_2_Picture_55.jpeg",
+                            "caption": "Logo: An apple-shaped icon with a bite taken out on the right side and a single leaf on top."
+                        },
+                        {
+                            "markdown_content": "![](_page_2_Picture_57.jpeg)",
+                            "near_chunks": [
+                                "**devices with end-to-end**\n\n**The new Passwords app makes it even easier to access account passwords, passkeys, Wi-Fi passwords, twofactor authentication codes, and more. It stores them securely and syncs across your**\n\n**Apple Intelligence protects your privacy at every step. With ondevice processing and Private Cloud Compute, no one but you can access your data — not even Apple.**\n\n",
+                                "**You can also control which contacts to share with an app, rather than giving it access to all your contacts. And you can choose to share more contacts over time.** **devices with end-to-end encryption.**\n\n### **Accessibility**\n\n**Eye Tracking makes it possible to navigate your iPhone and use your favorite apps just by moving your eyes, thanks to the power of machine learning and the front-facing camera.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_2_Picture_57.jpeg",
+                            "caption": "Logo: Apple logo in solid black, minimalist design."
+                        },
+                        {
+                            "markdown_content": "![](_page_3_Picture_5.jpeg)",
+                            "near_chunks": [
+                                "**Eye Tracking makes it possible to navigate your iPhone and use your favorite apps just by moving your eyes, thanks to the power of machine learning and the front-facing camera.**\n\n### **Accessibility**\n\n**You can also control which contacts to share with an app, rather than giving it access to all your contacts. And you can choose to share more contacts over time.** **devices with end-to-end encryption.**\n\n",
+                                "**Music Haptics matches the iPhone Taptic Engine with the rhythm of songs. So people who are deaf or hard of hearing can enjoy the Apple Music catalog in a whole new way.**\n\n**Learn about Apple and accessibility**\n\n**Vocal Shortcuts helps people with severe atypical speech record sounds that trigger specific actions on iPhone — set a timer, take a screenshot, scroll up and down, and more.**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_3_Picture_5.jpeg",
+                            "caption": "Icon: Blue musical note with overlapping circles on a black background."
+                        },
+                        {
+                            "markdown_content": "![](_page_3_Picture_9.jpeg)",
+                            "near_chunks": [
+                                "**Learn about Apple and accessibility**\n\n**Music Haptics matches the iPhone Taptic Engine with the rhythm of songs. So people who are deaf or hard of hearing can enjoy the Apple Music catalog in a whole new way.**\n\n**Eye Tracking makes it possible to navigate your iPhone and use your favorite apps just by moving your eyes, thanks to the power of machine learning and the front-facing camera.**\n\n",
+                                "**Vocal Shortcuts helps people with severe atypical speech record sounds that trigger specific actions on iPhone — set a timer, take a screenshot, scroll up and down, and more.**\n\n### **Significant others.**\n\n#### **iPhone and Mac**\n\nWith iPhone Mirroring, you can view your iPhone screen on your Mac and control it without picking up your phone. Continuity features also let you answer calls or messages right from your Mac. You can even copy images, video, or text from your iPhone and paste it all into a different app on your Mac. And with iCloud, you can access your files from either device.\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_3_Picture_9.jpeg",
+                            "caption": "Logo: Stylized blue geometric shapes on a black background, resembling overlapping rounded squares."
+                        },
+                        {
+                            "markdown_content": "![](_page_3_Picture_16.jpeg)",
+                            "near_chunks": [
+                                "**iPhone and AirPods**\n\n#### **iPhone and Apple Watch**\n\nWith iPhone Mirroring, you can view your iPhone screen on your Mac and control it without picking up your phone. Continuity features also let you answer calls or messages right from your Mac. You can even copy images, video, or text from your iPhone and paste it all into a different app on your Mac. And with iCloud, you can access your files from either device.\n\n",
+                                "### **Why Apple is the best place to buy iPhone.** Shop iPhone\n\n**Get flexible delivery**\n\nChoose from two-hour delivery\n\nfrom an Apple Store, free delivery,\n\n**and easy pickup.**\n\nor easy pickup options.\n\n### **Keep exploring iPhone.** Explore all iPhone\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_3_Picture_16.jpeg",
+                            "caption": "Picture: iPhone interface mirroring on a MacBook screen, showcasing seamless integration of Apple devices."
+                        },
+                        {
+                            "markdown_content": "![](_page_3_Figure_19.jpeg)",
+                            "near_chunks": [
+                                "or easy pickup options.\n\n**and easy pickup.**\n\nfrom an Apple Store, free delivery,\n\nChoose from two-hour delivery\n\n**Get flexible delivery**\n\n### **Why Apple is the best place to buy iPhone.** Shop iPhone\n\n**iPhone and AirPods**\n\n#### **iPhone and Apple Watch**\n\n",
+                                "### **Keep exploring iPhone.** Explore all iPhone\n\nCamera Control\n\nPro camera system Our most advanced 48MP Fusion camera 5x Telephoto camera 48MP Ultra Wide camera\n\nUp to 33 hours video playback ^f\n\nAdvanced dual-camera system Advanced 48MP Fusion camera 2x Telephoto 12MP Ultra Wide camera\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_3_Figure_19.jpeg",
+                            "caption": "Banner: Promotional text highlighting Apple trade-in deals, interest-free financing with Apple Card, and carrier deals offering up to $1000 in credit for new iPhone purchases."
+                        },
+                        {
+                            "markdown_content": "![](_page_3_Figure_22.jpeg)",
+                            "near_chunks": [
+                                "### **Keep exploring iPhone.** Explore all iPhone\n\nor easy pickup options.\n\n**and easy pickup.**\n\nfrom an Apple Store, free delivery,\n\nChoose from two-hour delivery\n\n**Get flexible delivery**\n\n### **Why Apple is the best place to buy iPhone.** Shop iPhone\n\n",
+                                "Camera Control\n\nPro camera system Our most advanced 48MP Fusion camera 5x Telephoto camera 48MP Ultra Wide camera\n\nUp to 33 hours video playback ^f\n\nAdvanced dual-camera system Advanced 48MP Fusion camera 2x Telephoto 12MP Ultra Wide camera\n\nUp to 27 hours video playback ^f\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_3_Figure_22.jpeg",
+                            "caption": "Banner: Advertisement featuring iPhone 16 Pro and iPhone 16 models, displaying prices, monthly payment options, and highlighting new Apple A18 chip features."
+                        },
+                        {
+                            "markdown_content": "![](_page_3_Picture_23.jpeg)",
+                            "near_chunks": [
+                                "### **Keep exploring iPhone.** Explore all iPhone\n\nor easy pickup options.\n\n**and easy pickup.**\n\nfrom an Apple Store, free delivery,\n\nChoose from two-hour delivery\n\n**Get flexible delivery**\n\n### **Why Apple is the best place to buy iPhone.** Shop iPhone\n\n",
+                                "Camera Control\n\nPro camera system Our most advanced 48MP Fusion camera 5x Telephoto camera 48MP Ultra Wide camera\n\nUp to 33 hours video playback ^f\n\nAdvanced dual-camera system Advanced 48MP Fusion camera 2x Telephoto 12MP Ultra Wide camera\n\nUp to 27 hours video playback ^f\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_3_Picture_23.jpeg",
+                            "caption": "Icon: An illustration of a phone with an arrow pointing downward, labeled \"Camera Control\" on a black background."
+                        },
+                        {
+                            "markdown_content": "![](_page_3_Picture_25.jpeg)",
+                            "near_chunks": [
+                                "Camera Control\n\n### **Keep exploring iPhone.** Explore all iPhone\n\nor easy pickup options.\n\n**and easy pickup.**\n\nfrom an Apple Store, free delivery,\n\nChoose from two-hour delivery\n\n**Get flexible delivery**\n\n### **Why Apple is the best place to buy iPhone.** Shop iPhone\n\n",
+                                "Pro camera system Our most advanced 48MP Fusion camera 5x Telephoto camera 48MP Ultra Wide camera\n\nUp to 33 hours video playback ^f\n\nAdvanced dual-camera system Advanced 48MP Fusion camera 2x Telephoto 12MP Ultra Wide camera\n\nUp to 27 hours video playback ^f\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_3_Picture_25.jpeg",
+                            "caption": "Logo: Apple logo in black, featuring a bitten apple silhouette."
+                        },
+                        {
+                            "markdown_content": "![](_page_3_Picture_27.jpeg)",
+                            "near_chunks": [
+                                "Pro camera system Our most advanced 48MP Fusion camera 5x Telephoto camera 48MP Ultra Wide camera\n\nCamera Control\n\n### **Keep exploring iPhone.** Explore all iPhone\n\nor easy pickup options.\n\n**and easy pickup.**\n\nfrom an Apple Store, free delivery,\n\nChoose from two-hour delivery\n\n",
+                                "Up to 33 hours video playback ^f\n\nAdvanced dual-camera system Advanced 48MP Fusion camera 2x Telephoto 12MP Ultra Wide camera\n\nUp to 27 hours video playback ^f\n\n### **iPhone**\n\n**Explore All iPhone iPhone 16 Pro**\n\nExplore iPhone\n\n**iPhone 16 iPhone 15 iPhone 14**\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_3_Picture_27.jpeg",
+                            "caption": "Icon: Simple battery icon on a black background, indicating power or charge."
+                        },
+                        {
+                            "markdown_content": "![](_page_3_Picture_30.jpeg)",
+                            "near_chunks": [
+                                "Advanced dual-camera system Advanced 48MP Fusion camera 2x Telephoto 12MP Ultra Wide camera\n\nUp to 33 hours video playback ^f\n\nPro camera system Our most advanced 48MP Fusion camera 5x Telephoto camera 48MP Ultra Wide camera\n\nCamera Control\n\n### **Keep exploring iPhone.** Explore all iPhone\n\n",
+                                "Up to 27 hours video playback ^f\n\n### **iPhone**\n\n**Explore All iPhone iPhone 16 Pro**\n\nExplore iPhone\n\n**iPhone 16 iPhone 15 iPhone 14**\n\n**Compare iPhone Switch from Android**\n\n**iPhone SE**\n\n* Trade-in values will vary based on the condition, year, and configuration of your eligible trade-in device. Not all devices are eligible for credit. You must be at least 18 years old to be eligible to trade in for credit or for an Apple Gift Card. Trade-in value may be applied toward qualifying new device purchase, or added to an Apple Gift Card. Actual value awarded is based on receipt of a qualifying device matching the description provided when estimate was made. Sales tax may be assessed on full value of a new device purchase. In-store trade-in requires presentation of a valid photo ID (local law may require saving this information). Offer may not be available in all stores, and may vary between in-store and online trade-in. Some stores may have additional requirements. Apple or its trade-in partners reserve the right to refuse or limit quantity of any trade-in transaction\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/_page_3_Picture_30.jpeg",
+                            "caption": "Icon: Minimalist battery symbol, outlined in white on a black background, indicating charge level status."
+                        },
+                        {
+                            "markdown_content": "| Shop iPhone | More from iPhone |\n| --- | --- |\n| Shop iPhone | iPhone Support |\n| iPhone Accessories | AppleCare+ for iPhone |\n| Apple Trade In | iOS 18 |\n| Carrier Deals at Apple | Apple Intelligence |\n| Financing | Apps by Apple |\n|  | iPhone Privacy |\n|  | iCloud+ |\n|  | Wallet, Pay, Card |",
+                            "near_chunks": [
+                                "**iPhone SE**\n\n**Compare iPhone Switch from Android**\n\n**iPhone 16 iPhone 15 iPhone 14**\n\nExplore iPhone\n\n**Explore All iPhone iPhone 16 Pro**\n\n### **iPhone**\n\nUp to 27 hours video playback ^f\n\nAdvanced dual-camera system Advanced 48MP Fusion camera 2x Telephoto 12MP Ultra Wide camera\n\n",
+                                "* Trade-in values will vary based on the condition, year, and configuration of your eligible trade-in device. Not all devices are eligible for credit. You must be at least 18 years old to be eligible to trade in for credit or for an Apple Gift Card. Trade-in value may be applied toward qualifying new device purchase, or added to an Apple Gift Card. Actual value awarded is based on receipt of a qualifying device matching the description provided when estimate was made. Sales tax may be assessed on full value of a new device purchase. In-store trade-in requires presentation of a valid photo ID (local law may require saving this information). Offer may not be available in all stores, and may vary between in-store and online trade-in. Some stores may have additional requirements. Apple or its trade-in partners reserve the right to refuse or limit quantity of any trade-in transaction\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/table_7397.png",
+                            "caption": "Table: Overview of iPhone shopping options, accessories, trade-in, financing, and various iPhone services including support, privacy, and software offerings like iOS 18 and Apple Intelligence.",
+                            "cells": [
+                                [
+                                    "Shop iPhone",
+                                    "More from iPhone"
+                                ],
+                                [
+                                    "Shop iPhone",
+                                    "iPhone Support"
+                                ],
+                                [
+                                    "iPhone Accessories",
+                                    "AppleCare+ for iPhone"
+                                ],
+                                [
+                                    "Apple Trade In",
+                                    "iOS 18"
+                                ],
+                                [
+                                    "Carrier Deals at Apple",
+                                    "Apple Intelligence"
+                                ],
+                                [
+                                    "Financing",
+                                    "Apps by Apple"
+                                ],
+                                [
+                                    "",
+                                    "iPhone Privacy"
+                                ],
+                                [
+                                    "",
+                                    "iCloud+"
+                                ],
+                                [
+                                    "",
+                                    "Wallet, Pay, Card"
+                                ]
+                            ],
+                            "merge_area": null
+                        },
+                        {
+                            "markdown_content": "| Shop and Learn | Account | Apple Store | For Business | Apple Values |\n| --- | --- | --- | --- | --- |\n| Store | Manage Your Apple Account | Find a Store | Apple and Business | Accessibility |\n| Mac | Apple Store Account | Genius Bar | Shop for Business | Education |\n| iPad | iCloud.com | Today at Apple | For Education | Environment |\n| iPhone | Entertainment | Group Reservations | Apple and Education | Inclusion and Diversity |\n| Watch |  | Apple Camp |  | Privacy |\n| Vision | Apple One | Apple Store App | Shop for K-12 | Racial Equity and Justice |\n|  | Apple TV+ |  | Shop for College |  |\n| AirPods | Apple Music | Certified Refurbished |  | Supply Chain |\n| TV & Home |  | Apple Trade In | For Healthcare |  |\n| AirTag | Apple Arcade | Financing | Apple in Healthcare | About Apple |\n| Accessories | Apple Fitness+ | Carrier Deals at Apple | Mac in Healthcare | Newsroom |\n| Gift Cards | Apple News+ | Order Status |  | Apple Leadership |\n|  |  |  | Health on Apple Watch |  |\n|  | Apple Podcasts | Shopping Help | Health Records on iPhone and | Career Opportunities |\n| Apple Wallet | Apple Books |  | iPad | Investors |\n| Wallet | App Store |  |  | Ethics & Compliance |\n| Apple Card |  |  | For Government | Events |\n| Apple Pay |  |  | Shop for Government | Contact Apple |\n| Apple Cash |  |  | Shop for Veterans and Military |  |",
+                            "near_chunks": [
+                                "#### iPhone iPhone 16 Pro\n\nSome features require specific hardware and software. For more information, see Feature Availability.\n\nFeatures are subject to change. Some features, applications, and services may not be available in all regions or all languages.\n\n",
+                                "More ways to shop: Find an Apple Store or other retailer near you. Or call 1-800-MY-APPLE.\n\n"
+                            ],
+                            "path": "/root/autodl-tmp/PPTAgent/log/test_iphone16/pdf_analysis/table_eff0.png",
+                            "caption": "Table: Overview of Apple services and offerings across various categories, including shopping options, account management, business solutions, and company values, available through different platforms such as Apple Stores, online services, and exclusive programs.",
+                            "cells": [
+                                [
+                                    "Shop and Learn",
+                                    "Account",
+                                    "Apple Store",
+                                    "For Business",
+                                    "Apple Values"
+                                ],
+                                [
+                                    "Store",
+                                    "Manage Your Apple Account",
+                                    "Find a Store",
+                                    "Apple and Business",
+                                    "Accessibility"
+                                ],
+                                [
+                                    "Mac",
+                                    "Apple Store Account",
+                                    "Genius Bar",
+                                    "Shop for Business",
+                                    "Education"
+                                ],
+                                [
+                                    "iPad",
+                                    "iCloud.com",
+                                    "Today at Apple",
+                                    "For Education",
+                                    "Environment"
+                                ],
+                                [
+                                    "iPhone",
+                                    "Entertainment",
+                                    "Group Reservations",
+                                    "Apple and Education",
+                                    "Inclusion and Diversity"
+                                ],
+                                [
+                                    "Watch",
+                                    "",
+                                    "Apple Camp",
+                                    "",
+                                    "Privacy"
+                                ],
+                                [
+                                    "Vision",
+                                    "Apple One",
+                                    "Apple Store App",
+                                    "Shop for K-12",
+                                    "Racial Equity and Justice"
+                                ],
+                                [
+                                    "",
+                                    "Apple TV+",
+                                    "",
+                                    "Shop for College",
+                                    ""
+                                ],
+                                [
+                                    "AirPods",
+                                    "Apple Music",
+                                    "Certified Refurbished",
+                                    "",
+                                    "Supply Chain"
+                                ],
+                                [
+                                    "TV & Home",
+                                    "",
+                                    "Apple Trade In",
+                                    "For Healthcare",
+                                    ""
+                                ],
+                                [
+                                    "AirTag",
+                                    "Apple Arcade",
+                                    "Financing",
+                                    "Apple in Healthcare",
+                                    "About Apple"
+                                ],
+                                [
+                                    "Accessories",
+                                    "Apple Fitness+",
+                                    "Carrier Deals at Apple",
+                                    "Mac in Healthcare",
+                                    "Newsroom"
+                                ],
+                                [
+                                    "Gift Cards",
+                                    "Apple News+",
+                                    "Order Status",
+                                    "",
+                                    "Apple Leadership"
+                                ],
+                                [
+                                    "",
+                                    "",
+                                    "",
+                                    "Health on Apple Watch",
+                                    ""
+                                ],
+                                [
+                                    "",
+                                    "Apple Podcasts",
+                                    "Shopping Help",
+                                    "Health Records on iPhone and",
+                                    "Career Opportunities"
+                                ],
+                                [
+                                    "Apple Wallet",
+                                    "Apple Books",
+                                    "",
+                                    "iPad",
+                                    "Investors"
+                                ],
+                                [
+                                    "Wallet",
+                                    "App Store",
+                                    "",
+                                    "",
+                                    "Ethics & Compliance"
+                                ],
+                                [
+                                    "Apple Card",
+                                    "",
+                                    "",
+                                    "For Government",
+                                    "Events"
+                                ],
+                                [
+                                    "Apple Pay",
+                                    "",
+                                    "",
+                                    "Shop for Government",
+                                    "Contact Apple"
+                                ],
+                                [
+                                    "Apple Cash",
+                                    "",
+                                    "",
+                                    "Shop for Veterans and Military",
+                                    ""
+                                ]
+                            ],
+                            "merge_area": null
+                        }
+                    ]
+                },
+                {
+                    "title": "Privacy",
+                    "content": "Apple Intelligence protects your privacy with on-device processing and Private Cloud Compute, ensuring only you can access your data, not even Apple. The new Passwords app simplifies access to account passwords, passkeys, Wi-Fi passwords, two-factor authentication codes, and more. It securely stores and syncs them across your devices with end-to-end encryption. Additionally, you can control which contacts to share with an app, opting to share more contacts over time.",
+                    "medias": []
+                },
+                {
+                    "title": "Accessibility",
+                    "content": "Eye Tracking enables navigation and app usage on your iPhone with eye movements, utilizing machine learning and the front-facing camera. Music Haptics pairs the iPhone Taptic Engine with song rhythms, offering a new way for people who are deaf or hard of hearing to enjoy Apple Music. Vocal Shortcuts allows individuals with severe atypical speech to record sounds that trigger specific iPhone actions like setting timers, taking screenshots, and scrolling.",
+                    "medias": []
+                },
+                {
+                    "title": "Significant Others",
+                    "content": "With iPhone Mirroring, view and control your iPhone screen on a Mac without needing to pick up the iPhone. Continuity features allow answering calls or messages directly from a Mac. You can also copy images, video, or text from your iPhone and paste them into different apps on a Mac. iCloud ensures file access from either device.",
+                    "medias": []
+                },
+                {
+                    "title": "Why Apple is the best place",
+                    "content": "Shop iPhone offers flexible delivery options, including two-hour delivery from an Apple Store, free delivery, and easy pickup options.",
+                    "medias": []
+                }
+            ],
+            "markdown_content": null
+        }
+    ],
+    "metadata": {
+        "product": "iPhone 16 Pro",
+        "title": "A18 Pro chip. The brains behind Apple Intelligence.",
+        "presentation-date": "2025-05-12"
+    }
+}

--- a/src/Sagi/templates/test_work_dir/slide_induction.json
+++ b/src/Sagi/templates/test_work_dir/slide_induction.json
@@ -1,0 +1,172 @@
+{
+    "opening": {
+        "slides": [
+            1
+        ],
+        "template_id": 1,
+        "content_schema": {
+            "presenters": {
+                "description": "names of the presenters on the slide",
+                "type": "text",
+                "data": [
+                    "Paul"
+                ]
+            },
+            "affiliation": {
+                "description": "affiliation or organization name of the presenter",
+                "type": "text",
+                "data": [
+                    "Microsoft"
+                ]
+            },
+            "date": {
+                "description": "presentation date formatted in year/month/day",
+                "type": "text",
+                "data": [
+                    "2025/5/26"
+                ]
+            },
+            "main title": {
+                "description": "title of the slide, indicating the main topic or subject",
+                "type": "text",
+                "data": [
+                    "GraphRAG"
+                ]
+            }
+        }
+    },
+    "table of contents": {
+        "slides": [
+            2
+        ],
+        "template_id": 2,
+        "content_schema": {
+            "main title": {
+                "description": "main title of the slide",
+                "type": "text",
+                "data": [
+                    "Table of Contents"
+                ]
+            },
+            "content bullets": {
+                "description": "list items summarizing the main sections of the presentation",
+                "type": "text",
+                "data": [
+                    "Introduction",
+                    "Method",
+                    "Experiment",
+                    "Conclusion"
+                ]
+            }
+        }
+    },
+    "ending": {
+        "slides": [
+            6
+        ],
+        "template_id": 6,
+        "content_schema": {
+            "main message": {
+                "description": "closing message of the slide",
+                "type": "text",
+                "data": [
+                    "Thank you for listening!"
+                ]
+            }
+        }
+    },
+    "Flowchart with Sequential Text Boxes and Explanatory Paragraph on the Right:image": {
+        "template_id": 3,
+        "slides": [
+            3
+        ],
+        "content_schema": {
+            "main title": {
+                "description": "main title of the slide",
+                "type": "text",
+                "data": [
+                    "Introduction"
+                ]
+            },
+            "content paragraph": {
+                "description": "content paragraph with theme color text",
+                "type": "text",
+                "data": [
+                    "GraphRAG is a structured, hierarchical approach to Retrieval Augmented Generation (RAG), as opposed to naive semantic-search approaches using plain text snippets. The GraphRAG process involves extracting a knowledge graph out of raw text, building a community hierarchy, generating summaries for these communities, and then leveraging these structures when perform RAG-based tasks.。"
+                ]
+            },
+            "supporting image": {
+                "description": "image illustrating a data processing pipeline",
+                "type": "image",
+                "data": [
+                    "Diagram: Flowchart illustrating a data processing pipeline from source documents to a global answer using text extraction, summarization, and community detection."
+                ]
+            }
+        }
+    },
+    "Title with Four Bullet Points in a Vertical List:text": {
+        "template_id": 4,
+        "slides": [
+            4
+        ],
+        "content_schema": {
+            "main title": {
+                "description": "main title of the slide",
+                "type": "text",
+                "data": [
+                    "Method"
+                ]
+            },
+            "section title": {
+                "description": "section title of this portion of the slide",
+                "type": "text",
+                "data": [
+                    "GraphRAG Workflow"
+                ]
+            },
+            "content paragraph": {
+                "description": "explanation of the workflow steps in the slide",
+                "type": "text",
+                "data": [
+                    "To start, the documents in the corpus are split into text chunks. The LLM extracts information from each chunk for downstream processing.",
+                    "In this step, the LLM is prompted to extract instances of important entities and the relationships between the entities from a given chunk. Additionally, the LLM generates short descriptions for the entities and relationships.",
+                    "The use of an LLM to extract entities, relationships, and claims is a form of abstractive summarization – these are meaningful summaries of concepts that, in the case of relationships and claims, may not be explicitly stated in the text. The entity/relationship/claim extraction processes creates multiple instances of a single element because an element is typically detected and extracted multiple times across documents."
+                ]
+            }
+        }
+    },
+    "Title with Grid and Paragraph Explanation Below:image": {
+        "template_id": 5,
+        "slides": [
+            5
+        ],
+        "content_schema": {
+            "main title": {
+                "description": "main title of the slide",
+                "type": "text",
+                "data": [
+                    "Conclusion"
+                ]
+            },
+            "content paragraph": {
+                "description": "conclusion paragraph summarizing the key points of the presentation",
+                "type": "text",
+                "data": [
+                    "We have presented GraphRAG, a RAG approach that combines knowledge graph generation andquery-focused summarization (QFS) to support human sensemaking over entire text corpora. Initialevaluations show substantial improvements over a vector RAG baseline for both the comprehensiveness and diversity of answers, as well as favorable comparisons to a global but graph-free approachusing map-reduce source text summarization. For situations requiring many global queries over thesame dataset, summaries of root-level communities in the entity-based graph index provide a dataindex that is both superior to vector RAG and achieves competitive performance to other globalmethods at a fraction of the token cost."
+                ]
+            },
+            "supplementary image": {
+                "description": "image providing additional visual information or context",
+                "type": "image",
+                "data": [
+                    "This is a picture of TABLE"
+                ]
+            }
+        }
+    },
+    "functional_keys": [
+        "opening",
+        "table of contents",
+        "ending"
+    ]
+}

--- a/src/Sagi/tools/stream_code_executor/stream_docker_command_line_code_executor.py
+++ b/src/Sagi/tools/stream_code_executor/stream_docker_command_line_code_executor.py
@@ -117,7 +117,7 @@ class StreamDockerCommandLineCodeExecutor(
                 # Abort if not supported
                 if lang not in self.SUPPORTED_LANGUAGES:
                     exitcode = 1
-                    logs_all += "\n" + f"unknown language {lang}"
+                    outputs += "\n" + f"unknown language {lang}"
                     break
 
                 # Check if there is a filename comment
@@ -187,7 +187,7 @@ class StreamDockerCommandLineCodeExecutor(
                     break
         finally:
             if self._delete_tmp_files:
-                for file in files:
+                for file in file_names:
                     try:
                         file.unlink()
                     except (OSError, FileNotFoundError):

--- a/src/Sagi/utils/json_handler.py
+++ b/src/Sagi/utils/json_handler.py
@@ -1,0 +1,111 @@
+import json
+
+
+def format_file_content(file_content_path: str):
+    """
+    Format the file_content json into a string that's easy for LLM to understand.
+
+    Args:
+        file_content_path (str): The path to the file_content json file.
+
+    Returns:
+        str: The formatted string.
+    """
+    with open(file_content_path, "r", encoding="utf-8") as f:
+        file_content = json.load(f)
+
+    formatted_texts = []
+
+    # Add metadata information
+    if "metadata" in file_content:
+        metadata = file_content["metadata"]
+        formatted_texts.append("=== Document Metadata ===")
+        for key, value in metadata.items():
+            formatted_texts.append(f"{key}: {value}")
+        formatted_texts.append("\n")
+
+    # Process each section
+    if "sections" in file_content:
+        for section in file_content["sections"]:
+            # Add section title
+            formatted_texts.append(f"## Section: {section['title']}")
+
+            # Process subsections
+            if "subsections" in section:
+                for subsection in section["subsections"]:
+                    formatted_texts.append(f"\n### Subsection: {subsection['title']}")
+
+                    # Add subsection content
+                    if "content" in subsection:
+                        formatted_texts.append(f"Content: {subsection['content']}")
+
+                    # Add media captions
+                    if "medias" in subsection and subsection["medias"]:
+                        formatted_texts.append("\nMedia Captions:")
+                        for media in subsection["medias"]:
+                            if "caption" in media:
+                                formatted_texts.append(f"- {media['caption']}")
+
+            formatted_texts.append("\n" + "=" * 50 + "\n")
+
+    return "\n".join(formatted_texts)
+
+
+def format_templates(slide_induction_path: str):
+    with open(slide_induction_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    # Filter out non-template items
+    templates = {
+        k: v for k, v in data.items() if isinstance(v, dict) and "template_id" in v
+    }
+
+    # Sort by template_id
+    templates = dict(sorted(templates.items(), key=lambda item: item[1]["template_id"]))
+
+    result = []
+    for name, tpl in templates.items():
+        template_id = tpl.get("template_id")
+        slides = tpl.get("slides", [])
+        content_schema = tpl.get("content_schema", {})
+
+        result.append(f"=== template_id: {template_id} ===")
+        result.append(f"Template name: {name}")
+        result.append(f"slides: {slides}")
+        result.append("Content Schema:")
+        for field, info in content_schema.items():
+            dtype = info.get("type", "")
+            data = info.get("data", [])
+            all_data = ", ".join(map(str, data))
+            result.append(f"  - {field} ({dtype})")
+            if all_data:
+                result.append(f"    data: {all_data}")
+        result.append("")
+
+    return "\n".join(result)
+
+
+def format_slide_info(slide: dict):
+    """
+    Format the high_level_plan json string into a list.
+
+    Args:
+        high_level_plan (str): The high_level_plan json string.
+    """
+    slide_info = f"""# Slide Info
+  - **slide_category**: {slide.get('category', 'N/A')}
+  - **Description**: {slide.get('description', 'N/A')}"""
+
+    return slide_info
+
+
+def get_template_num(slide_induction_path: str):
+    template_num = 0
+    with open(slide_induction_path, "r", encoding="utf-8") as f:
+        slide_induction = json.load(f)
+
+    for v in slide_induction.values():
+        if isinstance(v, dict) and "template_id" in v:
+            template_num = max(template_num, v["template_id"])
+
+    return template_num

--- a/src/Sagi/utils/prompt.py
+++ b/src/Sagi/utils/prompt.py
@@ -1,3 +1,11 @@
+SLIDE_CATEGORY_INFO = """
+Opening slide: The first slide that introduces the presentation, typically including the title, presenter's name, and other introductory information.
+Ending slide: The final slide that concludes the presentation, usually featuring a summary, conclusions, or a call to action, along with contact details or acknowledgments.
+Normal texts slide: Content slides that present information primarily through text, such as bullet points or paragraphs.
+Normal texts with images slide: Content slides that combine text with images or diagrams to enhance understanding and visual appeal.
+"""
+
+
 def get_step_triage_prompt(*, task: str, current_plan: str, names: list[str]) -> str:
     """Generates a prompt template for triaging the step execution to the right team member.
 
@@ -129,3 +137,65 @@ Based on the information gathered, provide the final answer to the original requ
 The answer should be phrased as if you were speaking to the user.
 """
     return template.format(task=task)
+
+
+def get_high_level_ppt_plan_prompt(*, task: str, file_content: str) -> str:
+    """Generates a prompt template for high-level PPT plan.
+
+    Args:
+        task: The current task
+        file_content: The file content
+    """
+    template = """
+You are an expert PowerPoint presentation planning assistant.
+
+Your task is to generate a clear, high-level PowerPoint presentation outline to guide slide-by-slide creation.
+
+Instructions:
+
+1. Review the provided content ({file_content}) and user query ({query}) carefully for key topics and objectives.
+2. Structure the outline using best practices for presentation design, ensuring logical flow and coherence.
+3. Represent each slide as a bullet point; each point must include:
+- The main purpose or idea of the slide (e.g., Introduction, Overview of Challenges, Proposed Solutions, Conclusion).
+- The assigned category for the slide, as defined in the following information: {slide_category_info}.
+4. Do not include detailed content or slide text; focus exclusively on slide purpose, category, and sequence.
+5. Organize the plan with a clear progression from introduction, main content, to conclusion/next steps, as appropriate for the subject.
+6. Include a minimum of 6 slides to ensure comprehensive coverage.
+7. Present the outline as a numbered list for clarity.
+
+Return only the slide-by-slide outline as the output.
+    """
+    return template.format(
+        file_content=file_content, query=task, slide_category_info=SLIDE_CATEGORY_INFO
+    )
+
+
+def get_template_selection_prompt(*, slide_content: str, template_options: str) -> str:
+    """Generates a prompt template for template selection.
+
+    Args:
+        slide_content: The content for the slide
+        template_options: Available template options to choose from
+    """
+    template = """
+You are a presentation design expert. Your task is to analyze a slide's content and select the most appropriate template from the provided options.
+
+## CRITICAL INSTRUCTION:
+**Return ONLY the template_id number. Do not include explanations, extra text, or modify the format.**
+
+## Task Steps:
+1. Read and understand the current slide's content.
+2. Review all provided template options.
+3. Select the template that aligns best with the slide's category, content type, and structure.
+4. Respond with the template_id number.
+
+## Slide Content:
+{slide_content}
+
+## Available Templates:
+{template_options}
+"""
+
+    return template.format(
+        slide_content=slide_content, template_options=template_options
+    )

--- a/src/Sagi/utils/prompt.py
+++ b/src/Sagi/utils/prompt.py
@@ -199,3 +199,31 @@ You are a presentation design expert. Your task is to analyze a slide's content 
     return template.format(
         slide_content=slide_content, template_options=template_options
     )
+
+
+def get_expand_plan_prompt(*, task: str, slide_content: str) -> str:
+    """Generates a prompt template for expand plan.
+
+    Args:
+        task: The current task
+        slide_content: The content for the slide
+    """
+    template = """
+    You are a plan expander. Your task is to expand the plan for the following slide content:
+
+    ## Slide Content:
+    {slide_content}
+
+    ## User Query:
+    {task}
+
+    ## Expl
+    ## Return the expanded plan in the following format:
+    {{
+        "name": "A short title for this group task",
+        "description": "Detailed explanation of the group task objective",
+        "data_collection_task": "Specific instructions for gathering data needed for this group task",
+        "code_executor_task": "Description of what code executor should do, JUST DETAILED DESCRIPTION IS OK, NOT ACTUAL CODE BLOCK."
+    }}
+    """
+    return template.format(task=task, slide_content=slide_content)

--- a/src/Sagi/workflows/plan_manager.py
+++ b/src/Sagi/workflows/plan_manager.py
@@ -19,6 +19,7 @@ class Step(BaseModel):
         state (Literal["pending", "completed", "failed", "in_progress"]): The current state of the step
         messages (List[BaseAgentEvent | BaseChatMessage]): The conversation messages associated with executing this step
         reflection (Optional[str]): The reflection after the step is completed
+        template_id (Optional[str]): The template ID of the step
     """
 
     step_id: str
@@ -28,6 +29,7 @@ class Step(BaseModel):
     state: Literal["pending", "completed", "failed", "in_progress"]
     reflection: Optional[str]
     messages: List[BaseAgentEvent | BaseChatMessage]
+    template_id: Optional[str]
 
     def dump(self) -> Dict:
         """
@@ -45,6 +47,7 @@ class Step(BaseModel):
             "reflection": self.reflection,
             "messages": [msg.dump() for msg in self.messages] if self.messages else [],
             # Messages sent by the Orchestrator agent and tool agents
+            "template_id": self.template_id,
         }
 
     @classmethod
@@ -66,6 +69,7 @@ class Step(BaseModel):
             state=data.get("state", "pending"),
             reflection=data.get("reflection"),
             messages=[BaseMessage.load(msg) for msg in data.get("messages", [])],
+            template_id=data.get("template_id", None),
         )
 
 
@@ -80,6 +84,7 @@ class Plan(BaseModel):
         awaiting_confirmation (bool): Whether the plan awaits user confirmation.
         summary (Optional[str]): Summary of the plan.
         shared_context (OrderedDict[str, str]): A dictionary to dynamically store and update the concise result summary of each completed task group.
+        group_template_ids (Dict[str, Optional[str]]): A dictionary to store template IDs for each group.
     """
 
     plan_id: str
@@ -90,6 +95,7 @@ class Plan(BaseModel):
     shared_context: OrderedDict[str, str] = Field(
         default_factory=OrderedDict
     )  # Initialize as empty OrderedDict
+    group_template_ids: Dict[int, Optional[str]] = Field(default_factory=dict)
 
     def get_current_step(self) -> Optional[Tuple[str, str]]:
         """
@@ -233,6 +239,7 @@ class Plan(BaseModel):
                 - awaiting_confirmation: Boolean indicating if the plan is awaiting user confirmation
                 - summary: The plan summary text
                 - shared_context: Dictionary mapping task group IDs to their summaries
+                - group_template_ids: Dictionary mapping task group IDs to their template IDs
         """
         return {
             "plan_id": self.plan_id,
@@ -243,6 +250,7 @@ class Plan(BaseModel):
             "shared_context": dict(
                 self.shared_context
             ),  # Convert OrderedDict to regular dict for serialization
+            "group_template_ids": self.group_template_ids,
         }
 
     @classmethod
@@ -260,6 +268,7 @@ class Plan(BaseModel):
                 - awaiting_confirmation: Boolean indicating if the plan is awaiting user confirmation
                 - summary: The plan summary text
                 - shared_context: Dictionary mapping task group IDs to their summaries
+                - group_template_ids: Dictionary mapping task group IDs to their template IDs
 
         Returns:
             Plan: A new Plan object populated with the deserialized data
@@ -275,7 +284,11 @@ class Plan(BaseModel):
             shared_context=OrderedDict(
                 data.get("shared_context", {})
             ),  # Convert dict back to OrderedDict
+            group_template_ids=data.get("group_template_ids", {}),
         )
+
+    def get_group_template_id(self, group_id: int) -> Optional[str]:
+        return self.group_template_ids.get(group_id, None)
 
 
 class PlanHistory(BaseModel):
@@ -400,7 +413,11 @@ class PlanManager:
         """
 
         def append_step(
-            steps: Dict[str, Step], step_id: int, content: str, group_id: int
+            steps: Dict[str, Step],
+            step_id: int,
+            content: str,
+            group_id: int,
+            template_id: Optional[str],
         ):
             """
             Utility function to append a step to the plan.
@@ -419,6 +436,7 @@ class PlanManager:
                 state="pending",
                 reflection=None,
                 messages=[],
+                template_id=template_id,
             )
 
         def validate_model_response(model_response: str) -> None:
@@ -463,28 +481,29 @@ class PlanManager:
         validate_model_response(model_response)
         current_plan_groups = json.loads(model_response)["groups"]
 
-        steps, step_id, group_id = {}, 0, 0
+        steps, group_template_ids, step_id, group_id = {}, {}, 0, 0
         for group in current_plan_groups:
             group_name = group["name"]
             group_description = group["description"]
             tasks_added = False
-
+            template_id = group.get("template_id", None)
             if group.get("data_collection_task"):
                 content = group["data_collection_task"]
-                append_step(steps, step_id, content, group_id)
+                append_step(steps, step_id, content, group_id, template_id)
                 step_id += 1
                 tasks_added = True
             if group.get("code_executor_task") and group.get(
                 "code_executor_task"
             ) not in ["N/A"]:
                 content = group["code_executor_task"]
-                append_step(steps, step_id, content, group_id)
+                append_step(steps, step_id, content, group_id, template_id)
                 step_id += 1
                 tasks_added = True
             if not tasks_added:
                 content = f"{group_name}: {group_description}"
-                append_step(steps, step_id, content, group_id)
+                append_step(steps, step_id, content, group_id, template_id)
                 step_id += 1
+            group_template_ids[group_id] = template_id
             group_id += 1
         # Create new plan
         self._current_plan = Plan(
@@ -493,6 +512,7 @@ class PlanManager:
             steps=steps,
             awaiting_confirmation=True,
             summary=None,
+            group_template_ids=group_template_ids,
         )
 
     def confirm_plan(self) -> None:
@@ -808,3 +828,9 @@ class PlanManager:
         """
         self._current_plan = None
         self._plan_history = PlanHistory(plan_history=[])
+
+    def get_group_template_id(self, group_id: int) -> Optional[str]:
+        if self._current_plan:
+            return self._current_plan.group_template_ids.get(group_id, None)
+        else:
+            raise ValueError("No running plan")

--- a/src/Sagi/workflows/planning.py
+++ b/src/Sagi/workflows/planning.py
@@ -1,5 +1,6 @@
 import os
 from contextlib import AsyncExitStack
+from enum import Enum
 from pathlib import Path
 from typing import List, Literal, Optional
 
@@ -20,8 +21,18 @@ from Sagi.tools.stream_code_executor.stream_docker_command_line_code_executor im
     StreamDockerCommandLineCodeExecutor,
 )
 from Sagi.tools.web_search_agent import WebSearchAgent
+from Sagi.utils.json_handler import get_template_num
 from Sagi.utils.load_config import load_toml_with_env_vars
 from Sagi.workflows.planning_group_chat import PlanningGroupChat
+
+
+class Slide(BaseModel):
+    category: str
+    description: str
+
+
+class HighLevelPlanPPT(BaseModel):
+    slides: List[Slide]
 
 
 class Step(BaseModel):
@@ -112,12 +123,29 @@ class PlanningWorkflow:
                 model_info=model_info,
                 max_tokens=config_planning_client["max_tokens"],
             )
+
+            self.template_based_planning_model_client = OpenAIChatCompletionClient(
+                model=config_planning_client["model"],
+                base_url=config_planning_client["base_url"],
+                api_key=config_planning_client["api_key"],
+                response_format=HighLevelPlanPPT,
+                model_info=model_info,
+                max_tokens=config_planning_client["max_tokens"],
+            )
         else:
             self.planning_model_client = OpenAIChatCompletionClient(
                 model=config_planning_client["model"],
                 base_url=config_planning_client["base_url"],
                 api_key=config_planning_client["api_key"],
                 response_format=PlanningResponse,
+                max_tokens=config_planning_client["max_tokens"],
+            )
+
+            self.template_based_planning_model_client = OpenAIChatCompletionClient(
+                model=config_planning_client["model"],
+                base_url=config_planning_client["base_url"],
+                api_key=config_planning_client["api_key"],
+                response_format=HighLevelPlanPPT,
                 max_tokens=config_planning_client["max_tokens"],
             )
 
@@ -224,9 +252,36 @@ class PlanningWorkflow:
     async def create(
         cls,
         config_path: str,
+        template_work_dir: str | None = None,
     ):
         self = cls(config_path)
 
+        if template_work_dir is not None:
+            config = load_toml_with_env_vars(config_path)
+            template_num = get_template_num(
+                os.path.join(template_work_dir, "slide_induction.json")
+            )
+
+            template_choices = [f"template_{i}" for i in range(1, template_num + 1)]
+            TemplateList = Enum("TemplateList", template_choices)
+
+            class TemplateSelection(BaseModel):
+                template_id: TemplateList
+
+            config_planning_client = config["model_clients"]["planning_client"]
+            if "model_info" in config_planning_client:
+                model_info = config_planning_client["model_info"]
+                model_info["family"] = ModelFamily.UNKNOWN
+                model_info = ModelInfo(**model_info)
+            else:
+                model_info = None
+
+            self.template_selection_model_client = OpenAIChatCompletionClient(
+                model=config_planning_client["model"],
+                base_url=config_planning_client["base_url"],
+                api_key=config_planning_client["api_key"],
+                response_format=TemplateSelection,
+            )
         self.session_manager = MCPSessionManager()
 
         web_search_server_params = StdioServerParams(
@@ -344,6 +399,9 @@ class PlanningWorkflow:
             reflection_model_client=self.reflection_model_client,
             domain_specific_agent=domain_specific_agent,  # Add this parameter
             step_triage_model_client=self.step_triage_model_client,
+            template_based_planning_model_client=self.template_based_planning_model_client,
+            template_selection_model_client=self.template_selection_model_client,
+            template_work_dir=template_work_dir,  # Add template work directory parameter
         )
         return self
 

--- a/src/Sagi/workflows/planning.py
+++ b/src/Sagi/workflows/planning.py
@@ -35,7 +35,7 @@ class HighLevelPlanPPT(BaseModel):
     slides: List[Slide]
 
 
-class Step(BaseModel):
+class Group(BaseModel):
     name: str
     description: str
     data_collection_task: Optional[str] = None
@@ -43,7 +43,7 @@ class Step(BaseModel):
 
 
 class PlanningResponse(BaseModel):
-    steps: List[Step]
+    groups: List[Group]
 
 
 class ReflectionResponse(BaseModel):
@@ -400,7 +400,11 @@ class PlanningWorkflow:
             domain_specific_agent=domain_specific_agent,  # Add this parameter
             step_triage_model_client=self.step_triage_model_client,
             template_based_planning_model_client=self.template_based_planning_model_client,
-            template_selection_model_client=self.template_selection_model_client,
+            template_selection_model_client=(
+                self.template_selection_model_client
+                if template_work_dir is not None
+                else None
+            ),
             template_work_dir=template_work_dir,  # Add template work directory parameter
         )
         return self

--- a/src/Sagi/workflows/planning.py
+++ b/src/Sagi/workflows/planning.py
@@ -132,6 +132,15 @@ class PlanningWorkflow:
                 model_info=model_info,
                 max_tokens=config_planning_client["max_tokens"],
             )
+
+            self.single_group_planning_model_client = OpenAIChatCompletionClient(
+                model=config_planning_client["model"],
+                base_url=config_planning_client["base_url"],
+                api_key=config_planning_client["api_key"],
+                response_format=Group,
+                model_info=model_info,
+                max_tokens=config_planning_client["max_tokens"],
+            )
         else:
             self.planning_model_client = OpenAIChatCompletionClient(
                 model=config_planning_client["model"],
@@ -146,6 +155,14 @@ class PlanningWorkflow:
                 base_url=config_planning_client["base_url"],
                 api_key=config_planning_client["api_key"],
                 response_format=HighLevelPlanPPT,
+                max_tokens=config_planning_client["max_tokens"],
+            )
+
+            self.single_group_planning_model_client = OpenAIChatCompletionClient(
+                model=config_planning_client["model"],
+                base_url=config_planning_client["base_url"],
+                api_key=config_planning_client["api_key"],
+                response_format=Group,
                 max_tokens=config_planning_client["max_tokens"],
             )
 
@@ -405,6 +422,7 @@ class PlanningWorkflow:
                 if template_work_dir is not None
                 else None
             ),
+            single_group_planning_model_client=self.single_group_planning_model_client,
             template_work_dir=template_work_dir,  # Add template work directory parameter
         )
         return self

--- a/src/Sagi/workflows/planning_group_chat.py
+++ b/src/Sagi/workflows/planning_group_chat.py
@@ -41,6 +41,7 @@ class PlanningGroupChat(BaseGroupChat):
         template_work_dir: str | None = None,  # for template working directory
         template_selection_model_client: ChatCompletionClient,
         template_based_planning_model_client: ChatCompletionClient,
+        single_group_planning_model_client: ChatCompletionClient,
     ):
         super().__init__(
             participants,
@@ -72,6 +73,7 @@ class PlanningGroupChat(BaseGroupChat):
         self._template_based_planning_model_client = (
             template_based_planning_model_client
         )
+        self._single_group_planning_model_client = single_group_planning_model_client
 
     async def _init(self, runtime: AgentRuntime) -> None:
         # Constants for the group chat manager.
@@ -184,6 +186,7 @@ class PlanningGroupChat(BaseGroupChat):
             template_work_dir=self._template_work_dir,  # for template working directory
             template_selection_model_client=self._template_selection_model_client,
             template_based_planning_model_client=self._template_based_planning_model_client,
+            single_group_planning_model_client=self._single_group_planning_model_client,
         )
 
     async def save_state(self) -> Mapping[str, Any]:

--- a/src/Sagi/workflows/planning_group_chat.py
+++ b/src/Sagi/workflows/planning_group_chat.py
@@ -38,6 +38,9 @@ class PlanningGroupChat(BaseGroupChat):
         domain_specific_agent: (
             AssistantAgent | None
         ) = None,  # for new feat: domain specific prompt
+        template_work_dir: str | None = None,  # for template working directory
+        template_selection_model_client: ChatCompletionClient,
+        template_based_planning_model_client: ChatCompletionClient,
     ):
         super().__init__(
             participants,
@@ -63,6 +66,11 @@ class PlanningGroupChat(BaseGroupChat):
         self._user_proxy = user_proxy  # for new feat: human in the loop
         self._domain_specific_agent = (
             domain_specific_agent  # for new feat: domain specific prompt
+        )
+        self._template_work_dir = template_work_dir  # for template working directory
+        self._template_selection_model_client = template_selection_model_client
+        self._template_based_planning_model_client = (
+            template_based_planning_model_client
         )
 
     async def _init(self, runtime: AgentRuntime) -> None:
@@ -173,6 +181,9 @@ class PlanningGroupChat(BaseGroupChat):
             step_triage_model_client=self._step_triage_model_client,
             user_proxy=self._user_proxy,  # for new feat: human in the loop
             domain_specific_agent=self._domain_specific_agent,  # for new feat: domain specific prompt
+            template_work_dir=self._template_work_dir,  # for template working directory
+            template_selection_model_client=self._template_selection_model_client,
+            template_based_planning_model_client=self._template_based_planning_model_client,
         )
 
     async def save_state(self) -> Mapping[str, Any]:

--- a/src/Sagi/workflows/planning_orchestrator.py
+++ b/src/Sagi/workflows/planning_orchestrator.py
@@ -694,6 +694,7 @@ class PlanningOrchestrator(BaseGroupChatManager):
         self, reason: str, cancellation_token: CancellationToken
     ) -> None:
         """Prepare the final answer for the task."""
+        breakpoint()
         context = self.messages_to_context(
             self._plan_manager.get_messages_of_current_plan()
         )

--- a/src/Sagi/workflows/planning_orchestrator.py
+++ b/src/Sagi/workflows/planning_orchestrator.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 import re
 from typing import Any, Dict, List, Mapping
 
@@ -46,11 +47,18 @@ from pydantic import BaseModel, Field
 from Sagi.tools.stream_code_executor.stream_code_executor import (
     CodeFileMessage,
 )
+from Sagi.utils.json_handler import (
+    format_file_content,
+    format_slide_info,
+    format_templates,
+)
 from Sagi.utils.prompt import (
     get_appended_plan_prompt,
     get_final_answer_prompt,
+    get_high_level_ppt_plan_prompt,
     get_reflection_step_completion_prompt,
     get_step_triage_prompt,
+    get_template_selection_prompt,
 )
 from Sagi.workflows.plan_manager import PlanManager
 
@@ -87,8 +95,11 @@ class PlanningOrchestrator(BaseGroupChatManager):
         planning_model_client: ChatCompletionClient,
         reflection_model_client: ChatCompletionClient,
         step_triage_model_client: ChatCompletionClient,
+        template_selection_model_client: ChatCompletionClient,
+        template_based_planning_model_client: ChatCompletionClient,
         user_proxy: Any | None = None,
         domain_specific_agent: Any | None = None,
+        template_work_dir: str | None = None,
     ):
         super().__init__(
             name=name,
@@ -110,6 +121,11 @@ class PlanningOrchestrator(BaseGroupChatManager):
         self._user_proxy = user_proxy
         self._domain_specific_agent = (
             domain_specific_agent  # for new feat: domain specific prompt
+        )
+        self._template_work_dir = template_work_dir
+        self._template_selection_model_client = template_selection_model_client
+        self._template_based_planning_model_client = (
+            template_based_planning_model_client
         )
         self._group_chat_manager_topic_type = group_chat_manager_topic_type
         self._prompt_templates = {}  # to store domain specific prompts
@@ -166,7 +182,10 @@ class PlanningOrchestrator(BaseGroupChatManager):
             if self._plan_manager.get_plan_count() > 1:
                 await self._get_appended_plan(message, ctx)
             else:
-                await self._get_initial_plan(message, ctx)
+                if self._template_work_dir is not None:
+                    await self._get_initial_plan_based_templates(message, ctx)
+                else:
+                    await self._get_initial_plan(message, ctx)
         else:
             await self._human_in_the_loop(message, ctx)
 
@@ -308,6 +327,50 @@ class PlanningOrchestrator(BaseGroupChatManager):
         await self._get_plan_and_feedback(
             task, plan_prompt, facts_message, self._planning_model_client, ctx
         )
+
+    async def _get_initial_plan_based_templates(
+        self, message: UserInputMessage, ctx: MessageContext
+    ) -> None:
+        """Create the initial plan based on user input and templates"""
+
+        # Compose the task from message contents
+        task = await self._compose_task(message)
+        logging.info(f"Task: {task}")
+
+        file_content_path = os.path.join(self._template_work_dir, "file_content.json")
+        high_level_ppt_plan_prompt = get_high_level_ppt_plan_prompt(
+            task=task, file_content=format_file_content(file_content_path)
+        )
+
+        template_based_high_level_ppt_plan = await self._llm_create(
+            self._template_based_planning_model_client,
+            [SystemMessage(content=high_level_ppt_plan_prompt, source=self._name)],
+            ctx.cancellation_token,
+        )
+
+        template_based_high_level_ppt_plan_enum = json.loads(
+            template_based_high_level_ppt_plan
+        )
+
+        slide_induction_path = os.path.join(
+            self._template_work_dir, "slide_induction.json"
+        )
+        template_options = format_templates(slide_induction_path)
+        for _, slide in enumerate(template_based_high_level_ppt_plan_enum["slides"]):
+            template_selection_prompt = get_template_selection_prompt(
+                slide_content=format_slide_info(slide),
+                template_options=template_options,
+            )
+            template_selection_response = await self._llm_create(
+                self._template_selection_model_client,
+                [SystemMessage(content=template_selection_prompt, source=self._name)],
+                ctx.cancellation_token,
+            )
+            template_selection = json.loads(template_selection_response)
+            slide["template_id"] = template_selection["template_id"]
+
+        breakpoint()
+        # TODO: expand the plan to consistent with current implementation
 
     async def _get_appended_plan(
         self, message: UserInputMessage, ctx: MessageContext


### PR DESCRIPTION
- Feat: add template-based plan generation and make it consistent with existing plan format. Now if pass a `template_work_dir` argument when run `cli.py `, for example, `python cli.py --template_work_dir /chatbot/src/Sagi/templates/test_work_dir`, it will use the template-based plan generation, each group task will have a non-empty `template_id` (prepared test files in the directory `templates/test_work_dir` already for test).
- Refactor: invoke `Group` concept to avoid disambiguation.
- Fix: minor fixes for prompts, `setup.sh` and code executor.

Note: now template-based plan generation does not support human in the loop modifying the plan, mark as `TODO `in function `_get_initial_plan_based_templates` of `workflows/planning_orchestrator.py`