### PR TITLE
feat: modify the schema for MultiRoundMemory Table to enable the use of halfvec & resource manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "redis==6.2.0",
     "sqlalchemy[asyncpg]==2.0.40",
     "sqlmodel==0.0.24",
+    "alembic==1.16.5",
     "tiktoken>=0.9.0",
     "tomli>=2.2.1",
     "pytest-asyncio==0.26.0",


### PR DESCRIPTION
Following the schema in api/schema

SQL for altering the table: 

```
ALTER TABLE public."MultiRoundMemory" 
ALTER COLUMN embedding TYPE public.halfvec(4096),
ALTER COLUMN id TYPE character varying;
```
